### PR TITLE
Delete obj.meta

### DIFF
--- a/Assets/IBMWatsonSDK/IBMSdkCore/ThirdParty/Jwt/src/JWT/obj.meta
+++ b/Assets/IBMWatsonSDK/IBMSdkCore/ThirdParty/Jwt/src/JWT/obj.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 60170f00905324f1f9a5dbde500abda0
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
2022-10-20T04:09:37.4480566Z A meta data file (.meta) exists but its folder 'Assets/IBMWatsonSDK/IBMSdkCore/ThirdParty/Jwt/src/JWT/obj' can't be found, and has been created. Empty directories cannot be stored in version control, so it's assumed that the meta data file is for an empty directory in version control. When moving or deleting folders outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.