### PR TITLE
Delete ExperienceAPI.meta

### DIFF
--- a/Assets/MirageXR/Common/ExperienceAPI.meta
+++ b/Assets/MirageXR/Common/ExperienceAPI.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 6a911ac88fb3b4edd8be4a81d1ec3078
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Directory has moved a level lower and there is already an according meta file.

2022-10-20T04:09:37.4505668Z A meta data file (.meta) exists but its folder 'Assets/MirageXR/Common/ExperienceAPI' can't be found, and has been created. Empty directories cannot be stored in version control, so it's assumed that the meta data file is for an empty directory in version control. When moving or deleting folders outside of Unity, please ensure that the corresponding .meta file is moved or deleted along with it.