### PR TITLE
Updated cache action on Linux

### DIFF
--- a/.github/workflows/linux_workflow.yml
+++ b/.github/workflows/linux_workflow.yml
@@ -67,12 +67,12 @@ jobs:
 
       # Cache
       - name: Caching
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: Library
-          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          key: Library-linux-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
           restore-keys: |
-            Library-
+            Library-linux
 
       # Build stage
       - name: Unity builder

--- a/.github/workflows/linux_workflow.yml
+++ b/.github/workflows/linux_workflow.yml
@@ -29,12 +29,12 @@ jobs:
 
       # Cache
       - name: Caching
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: Library
-          key: Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          key: Library-linux-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
           restore-keys: |
-            Library-
+            Library-linux
 
       # Test stage
       - name: Unity Test runner (edit and play mode)


### PR DESCRIPTION
This pull request updates the cache action to version 3 for the Linux pipeline. This gets rid of deprecation warnings that are triggered by the v2 cache action.

Moreover, this pull request adds a "linux" prefix to the caches which are produced on the Linux workflow. If a key for a cache is not found, GitHub will take a cache where the prefix matches. By calling caches on Linux "Library-linux" and on Windows "Library-buildWindows", it should be ensured that a Linux build does not accidentally load a Windows cache.