### PR TITLE
Illegal character zip check

### DIFF
--- a/Assets/MirageXR/Common/Scripts/CombinedEditor/ActionDetailView/Annotation Editors/ModelEditor.cs
+++ b/Assets/MirageXR/Common/Scripts/CombinedEditor/ActionDetailView/Annotation Editors/ModelEditor.cs
@@ -32,6 +32,8 @@ namespace MirageXR
 
         public void Create(string modelName)
         {
+            modelName = ZipUtilities.CheckFileForIllegalCharacters(modelName);
+
             Vector3 offset;
             if (annotationToEdit != null)
             {

--- a/Assets/MirageXR/Common/Scripts/ZipUtilities.cs
+++ b/Assets/MirageXR/Common/Scripts/ZipUtilities.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.Zip;
-using UnityEngine;
 
 /// <summary>
 /// Utilities for handling ZIP files
@@ -131,9 +130,8 @@ public static class ZipUtilities
     public static string CheckFileForIllegalCharacters(string file)
     {
         string characters = "\\:*?\"<>|";
-        char[] charList = characters.ToCharArray();
 
-        foreach (char c in charList)
+        foreach (char c in characters.ToCharArray())
         {
             if (file.Contains(c))
             {

--- a/Assets/MirageXR/Common/Scripts/ZipUtilities.cs
+++ b/Assets/MirageXR/Common/Scripts/ZipUtilities.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.Zip;
 
@@ -126,19 +127,10 @@ public static class ZipUtilities
     /// <summary>
     /// Checks a given string for the illegal file name characters \ : * ? " < > |
     /// </summary>
-    /// <param name="file">The file name to be checked</param>
-    public static string CheckFileForIllegalCharacters(string file)
+    /// <param name="fileName">The file name to be checked</param>
+    public static string CheckFileForIllegalCharacters(string fileName)
     {
-        string characters = "\\:*?\"<>|";
-
-        foreach (char c in characters.ToCharArray())
-        {
-            if (file.Contains(c))
-            {
-                file = file.Replace(c.ToString(), string.Empty);
-            }
-        }
-
-        return file;
+        const string characters = "[\\:*?\"<>|]";
+        return Regex.Replace(fileName, characters, string.Empty);
     }
 }

--- a/Assets/MirageXR/Common/Scripts/ZipUtilities.cs
+++ b/Assets/MirageXR/Common/Scripts/ZipUtilities.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using ICSharpCode.SharpZipLib.Zip;
+using UnityEngine;
 
 /// <summary>
 /// Utilities for handling ZIP files
@@ -22,7 +23,7 @@ public static class ZipUtilities
             {
                 if (!zipEntry.IsFile) continue;
 
-                var entryFileName = zipEntry.Name;
+                var entryFileName = CheckFileForIllegalCharacters(zipEntry.Name);
                 var fullZipToPath = Path.Combine(outFolder, entryFileName);
                 var directoryName = Path.GetDirectoryName(fullZipToPath);
                 if (!string.IsNullOrEmpty(directoryName))
@@ -54,7 +55,9 @@ public static class ZipUtilities
         if (compressionLevel > 9) compressionLevel = 9;
         if (compressionLevel < 0) compressionLevel = 0;
         zipStream.SetLevel(compressionLevel);
-        var folderName = Path.GetDirectoryName(path);
+
+        var folderName = CheckFileForIllegalCharacters(Path.GetDirectoryName(path));
+
         if (Directory.Exists(path) && folderName != null)
         {
             var folderOffset = folderName.Length + (folderName.EndsWith(slash) ? 0 : 1);
@@ -118,5 +121,26 @@ public static class ZipUtilities
             await fileStream.CopyToAsync(zipStream);
         }
         zipStream.CloseEntry();
+    }
+
+    /// <returns>The inputed file name without illegal characters</returns>
+    /// <summary>
+    /// Checks a given string for the illegal file name characters \ : * ? " < > |
+    /// </summary>
+    /// <param name="file">The file name to be checked</param>
+    public static string CheckFileForIllegalCharacters(string file)
+    {
+        string characters = "\\:*?\"<>|";
+        char[] charList = characters.ToCharArray();
+
+        foreach (char c in charList)
+        {
+            if (file.Contains(c))
+            {
+                file = file.Replace(c.ToString(), string.Empty);
+            }
+        }
+
+        return file;
     }
 }

--- a/Assets/MirageXR/Player/Scripts/Augmentations/Model/Model.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/Model/Model.cs
@@ -90,6 +90,12 @@ namespace MirageXR
         private void LoadModel(ToggleObject obj)
         {
             startLoadTime = Time.time;
+            Debug.Log("obj.option = " + obj.option);
+
+            obj.option = ZipUtilities.CheckFileForIllegalCharacters(obj.option);
+
+            Debug.Log("File name = " + obj.option);
+
             var loadPath = Path.Combine(RootObject.Instance.activityManager.ActivityPath, obj.option, "scene.gltf");
 
             Debug.Log($"Loading model: {loadPath}");

--- a/Assets/MirageXR/Player/Scripts/Augmentations/Model/Model.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/Model/Model.cs
@@ -90,11 +90,8 @@ namespace MirageXR
         private void LoadModel(ToggleObject obj)
         {
             startLoadTime = Time.time;
-            Debug.Log("obj.option = " + obj.option);
 
             obj.option = ZipUtilities.CheckFileForIllegalCharacters(obj.option);
-
-            Debug.Log("File name = " + obj.option);
 
             var loadPath = Path.Combine(RootObject.Instance.activityManager.ActivityPath, obj.option, "scene.gltf");
 

--- a/Assets/MirageXR/Player/Scripts/Mobile/ContentEditors/ModelEditorView.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/ContentEditors/ModelEditorView.cs
@@ -370,6 +370,8 @@ public class ModelEditorView : PopupEditorBase
 
     protected override void OnAccept()
     {
+        _previewItem.name = ZipUtilities.CheckFileForIllegalCharacters(_previewItem.name);
+
         var predicate = $"3d:{_previewItem.name}";
         if (_content != null)
         {


### PR DESCRIPTION
Added CheckFileForIllegalCharacters method to zip utilities which checks a file name or path for illegal file characters and removes them. The new method is used when zipping and unzipping an activities ARLEM file and when creating a 3D model augmentation.

Closes #1222 
