### PR TITLE
Activity Settings Changes

### DIFF
--- a/Assets/MirageXR/Player/Scripts/Moodle/DBManager.cs
+++ b/Assets/MirageXR/Player/Scripts/Moodle/DBManager.cs
@@ -80,6 +80,15 @@ namespace MirageXR
         private const string SKETCHFAB_TOKEN_RENEW_KEY = "Sketchfab_token_last_renew_date";
         private const string SKETCHFAB_TOKEN_RENEW_DEFAULT = "";
 
+        private const string LOCAL_SAVE = "LocalSave";
+        private const bool LOCAL_SAVE_DEFAULT = true;
+
+        private const string CLOUD_SAVE = "CloudSave";
+        private const bool CLOUD_SAVE_DEFAULT = false;
+
+        private const string SHOW_PUBLIC_UPLOAD_WARNING = "DontShowPublicUploadWarning";
+        private const bool SHOW_PUBLIC_UPLOAD_WARNING_DEFAULT = true;
+
 
         private const int SKETCHFAB_RENEW_DYAS_COOLDOWN = 5;
 
@@ -111,8 +120,9 @@ namespace MirageXR
         private static readonly PrefsStringValue _sketchfabTokenRenewDate = new PrefsStringValue(SKETCHFAB_TOKEN_RENEW_KEY, SKETCHFAB_TOKEN_RENEW_DEFAULT);
         private static readonly PrefsBoolValue _showBigCards = new PrefsBoolValue(SHOW_BIG_CARDS_KEY, SHOW_BIG_CARDS_DEFAULT);
 
-        private static bool _localSave;
-        private static bool _cloudSave;
+        private static readonly PrefsBoolValue _localSave = new PrefsBoolValue(LOCAL_SAVE, LOCAL_SAVE_DEFAULT);
+        private static readonly PrefsBoolValue _cloudSave = new PrefsBoolValue(CLOUD_SAVE, CLOUD_SAVE_DEFAULT);
+        private static readonly PrefsBoolValue _showPublicUploadWarning = new PrefsBoolValue(SHOW_PUBLIC_UPLOAD_WARNING, SHOW_PUBLIC_UPLOAD_WARNING_DEFAULT);
 
         public static bool isNeedToRenewSketchfabToken => sketchfabLastTokenRenewDate <= DateTime.Now.AddDays(-SKETCHFAB_RENEW_DYAS_COOLDOWN);
 
@@ -134,14 +144,20 @@ namespace MirageXR
 
         public static bool publicLocalSave
         {
-            get => _localSave;
-            set => _localSave = value;
+            get => _localSave.Value;
+            set => _localSave.Value = value;
         }
 
         public static bool publicCloudSave
         {
-            get => _cloudSave;
-            set => _cloudSave = value;
+            get => _cloudSave.Value;
+            set => _cloudSave.Value = value;
+        }
+
+        public static bool publicShowPublicUploadWarning
+        {
+            get => _showPublicUploadWarning.Value;
+            set => _showPublicUploadWarning.Value = value;
         }
 
         public static bool showBigCards

--- a/Assets/MirageXR/Player/Scripts/Moodle/DBManager.cs
+++ b/Assets/MirageXR/Player/Scripts/Moodle/DBManager.cs
@@ -111,6 +111,9 @@ namespace MirageXR
         private static readonly PrefsStringValue _sketchfabTokenRenewDate = new PrefsStringValue(SKETCHFAB_TOKEN_RENEW_KEY, SKETCHFAB_TOKEN_RENEW_DEFAULT);
         private static readonly PrefsBoolValue _showBigCards = new PrefsBoolValue(SHOW_BIG_CARDS_KEY, SHOW_BIG_CARDS_DEFAULT);
 
+        private static bool _localSave;
+        private static bool _cloudSave;
+
         public static bool isNeedToRenewSketchfabToken => sketchfabLastTokenRenewDate <= DateTime.Now.AddDays(-SKETCHFAB_RENEW_DYAS_COOLDOWN);
 
         public static DateTime sketchfabLastTokenRenewDate
@@ -127,6 +130,18 @@ namespace MirageXR
         {
             get => _publicUploadPrivacy.Value;
             set => _publicUploadPrivacy.Value = value;
+        }
+
+        public static bool publicLocalSave
+        {
+            get => _localSave;
+            set => _localSave = value;
+        }
+
+        public static bool publicCloudSave
+        {
+            get => _cloudSave;
+            set => _cloudSave = value;
         }
 
         public static bool showBigCards

--- a/Assets/MirageXR/Tests/NewUI/ActivitySettings.cs
+++ b/Assets/MirageXR/Tests/NewUI/ActivitySettings.cs
@@ -34,6 +34,8 @@ public class ActivitySettings : PopupBase
 
         _btnDelete.interactable = _container != null;
 
+        ValueHasBeenChanged();
+
         ResetValues();
     }
 
@@ -45,8 +47,15 @@ public class ActivitySettings : PopupBase
     private void ResetValues()
     {
         _togglePublicUpload.isOn = DBManager.publicUploadPrivacy;
-        _toggleLocalSave.isOn = false;
-        _btnSave.interactable = false;
+        _toggleLocalSave.isOn = DBManager.publicLocalSave;
+        _toggleUploadToCloud.isOn = DBManager.publicCloudSave;
+    }
+
+    private void SetValues()
+    {
+        DBManager.publicUploadPrivacy = _togglePublicUpload.isOn;
+        DBManager.publicLocalSave = _toggleLocalSave.isOn;
+        DBManager.publicCloudSave = _toggleUploadToCloud.isOn;
     }
 
     protected override bool TryToGetArguments(params object[] args)
@@ -84,7 +93,24 @@ public class ActivitySettings : PopupBase
 
     private void ValueHasBeenChanged()
     {
-        _btnSave.interactable = true;
+        if (!_toggleUploadToCloud.isOn && !_toggleLocalSave.isOn)
+        {
+            _btnSave.interactable = false;
+        }
+        else
+        {
+            _btnSave.interactable = true;
+        }
+
+        if (!_toggleUploadToCloud.isOn)
+        {
+            _togglePublicUpload.isOn = false;
+            _togglePublicUpload.interactable = false;
+        }
+        else
+        {
+            _togglePublicUpload.interactable = true;
+        }
     }
 
     private void OnPreviewClicked()
@@ -96,6 +122,7 @@ public class ActivitySettings : PopupBase
 
     private void OnCloseClicked()
     {
+        SetValues();
         Close();
     }
 
@@ -111,6 +138,7 @@ public class ActivitySettings : PopupBase
         }
 
         DBManager.publicUploadPrivacy = _togglePublicUpload.isOn;
+        SetValues();
         ResetValues();
         Close();
     }

--- a/Assets/MirageXR/Tests/NewUI/ActivitySettings.cs
+++ b/Assets/MirageXR/Tests/NewUI/ActivitySettings.cs
@@ -81,11 +81,11 @@ public class ActivitySettings : PopupBase
         if(value && _toggleUploadToCloud.isOn && DBManager.publicShowPublicUploadWarning)
         {
             RootView_v2.Instance.dialog.ShowMiddle(
-            "Public Upload",
-            "You have selected public upload. Once uploaded, this activity will be visable to all users.",
-            "Don't show again", () => DontShowPublicUploadWarning(),
-            "OK", () => Debug.Log("Ok!"),
-            true);
+                "Public Upload",
+                "You have selected public upload. Once uploaded, this activity will be visable to all users.",
+                "Don't show again", () => DontShowPublicUploadWarning(),
+                "OK", () => Debug.Log("Ok!"),
+                true);
         }
 
         ValueHasBeenChanged();
@@ -108,14 +108,7 @@ public class ActivitySettings : PopupBase
 
     private void ValueHasBeenChanged()
     {
-        if (!_toggleUploadToCloud.isOn && !_toggleLocalSave.isOn)
-        {
-            _btnSave.interactable = false;
-        }
-        else
-        {
-            _btnSave.interactable = true;
-        }
+        _btnSave.interactable = _toggleUploadToCloud.isOn || _toggleLocalSave.isOn;
 
         if (!_toggleUploadToCloud.isOn)
         {

--- a/Assets/MirageXR/Tests/NewUI/ActivitySettings.cs
+++ b/Assets/MirageXR/Tests/NewUI/ActivitySettings.cs
@@ -78,7 +78,22 @@ public class ActivitySettings : PopupBase
 
     private void OnValueChangedPublicUpload(bool value)
     {
+        if(value && _toggleUploadToCloud.isOn && DBManager.publicShowPublicUploadWarning)
+        {
+            RootView_v2.Instance.dialog.ShowMiddle(
+            "Public Upload",
+            "You have selected public upload. Once uploaded, this activity will be visable to all users.",
+            "Don't show again", () => DontShowPublicUploadWarning(),
+            "OK", () => Debug.Log("Ok!"),
+            true);
+        }
+
         ValueHasBeenChanged();
+    }
+
+    private void DontShowPublicUploadWarning()
+    {
+        DBManager.publicShowPublicUploadWarning = false;
     }
 
     private void OnValueChangedSaveToggle(bool value)


### PR DESCRIPTION
changed activity settings to remember all settings, the user can publish as long as either local or cloud is checked, and public upload is only available when cloud is checked.

closes #1134, #1267 and #1268 

Added popup warning when selecting public upload closing #1132 