### PR TITLE
Fix for #1192, calibration now deactivates current action and activates first action before reloading the activity

### DIFF
--- a/Assets/MirageXR/Player/Scripts/Managers/Workplace/WorkplaceManager.cs
+++ b/Assets/MirageXR/Player/Scripts/Managers/Workplace/WorkplaceManager.cs
@@ -299,6 +299,8 @@ namespace MirageXR
         /// <param name="origin">Origin transform from the calibration target.</param>
         public async Task CalibrateWorkplace(Transform origin, bool isNewPosition = false)
         {
+            await activityManager.ActivateFirstAction();
+
             if (isNewPosition)
             {
                 await PerformEditModeCalibration();


### PR DESCRIPTION
Closes #1192 

added ActivateFirstAction to CalibrateWorkplace in WorkplaceManager to clear augmentations when calibrating