### PR TITLE
Fix for #1141, FetchAndUpdateView is now only called when moving onto home page rather than on each activity save

### DIFF
--- a/Assets/MirageXR/Player/Scripts/Managers/Activity/ActivityLocalFiles.cs
+++ b/Assets/MirageXR/Player/Scripts/Managers/Activity/ActivityLocalFiles.cs
@@ -19,12 +19,19 @@ namespace MirageXR
 
         public static void SaveData(Activity activity)
         {
-            var fileName = string.Format(JSON_NAME_FORMAT, activity.id);
-            var recFilePath = Path.Combine(Application.persistentDataPath, fileName);
-            var json = ActivityParser.Serialize(activity);
-            File.WriteAllText(recFilePath, json);
-            EventManager.ActivitySaved();
-            RootObject.Instance.workplaceManager.SaveWorkplace();
+            try
+            {
+                var fileName = string.Format(JSON_NAME_FORMAT, activity.id);
+                var recFilePath = Path.Combine(Application.persistentDataPath, fileName);
+                var json = ActivityParser.Serialize(activity);
+                File.WriteAllText(recFilePath, json);
+                EventManager.ActivitySaved();
+                RootObject.Instance.workplaceManager.SaveWorkplace();
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Error when saving activity: " + e);
+            }
         }
 
         public static void MoveData(string oldActivityId, string activityId)

--- a/Assets/MirageXR/Tests/NewUI/ActivityListView_v2.cs
+++ b/Assets/MirageXR/Tests/NewUI/ActivityListView_v2.cs
@@ -54,7 +54,6 @@ public class ActivityListView_v2 : BaseView
 
         _panelSize = _panel.sizeDelta;
 
-        EventManager.OnActivitySaved += FetchAndUpdateView;
         EventManager.OnActivityStarted += ShowBackButtons;
 
         FetchAndUpdateView();
@@ -62,7 +61,6 @@ public class ActivityListView_v2 : BaseView
 
     private void OnDestroy()
     {
-        EventManager.OnActivitySaved -= FetchAndUpdateView;
         EventManager.OnActivityStarted -= ShowBackButtons;
     }
 

--- a/Assets/MirageXR/Tests/NewUI/RootView_v2.cs
+++ b/Assets/MirageXR/Tests/NewUI/RootView_v2.cs
@@ -170,6 +170,7 @@ public class RootView_v2 : BaseView
 
     public void ShowHomeView()
     {
+        activityListView.FetchAndUpdateView();
         _pageView.currentPageIndex = 0;
     }
 


### PR DESCRIPTION
Closes #1141 

Calling FetchAndUpdateView on each activity save was causing an "IOException: Sharing violation" error when deleting an augmentation after adding a new step. Now we only call FetchAndUpdateView when opening the home page as we only need to update this list when opening this page. Also added a try catch to the SaveData method. 