### PR TITLE
Verbose Logging System

### DIFF
--- a/Assets/MirageXR/Common/Scripts/DataModel/WorkplaceViewUpdater.cs
+++ b/Assets/MirageXR/Common/Scripts/DataModel/WorkplaceViewUpdater.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -40,10 +41,10 @@ namespace MirageXR
             // If workplace has anchors which have not been calibrated...
             if (workplaceManager.calibrationPairs.Count > 0 && !UiManager.Instance.IsCalibrated)
             {
-                Debug.Log("Workplace has uncalibrated anchors. Please re-run the calibration");
+                AppLog.LogWarning("Workplace has uncalibrated anchors. Please re-run the calibration");
             }
 
-            Debug.Log("********** EventManager.WorkplaceLoaded");
+            AppLog.LogInfo("********** EventManager.WorkplaceLoaded");
             // SUGGESTION Use a different event here that symbolizes the end of the view update by the model
             EventManager.WorkplaceLoaded();
         }

--- a/Assets/MirageXR/Common/Scripts/Services/MirageXRServiceBootstrapper.cs
+++ b/Assets/MirageXR/Common/Scripts/Services/MirageXRServiceBootstrapper.cs
@@ -2,6 +2,7 @@
 using i5.Toolkit.Core.ExperienceAPI;
 using i5.Toolkit.Core.OpenIDConnectClient;
 using i5.Toolkit.Core.ServiceCore;
+using i5.Toolkit.Core.VerboseLogging;
 using UnityEngine;
 
 namespace MirageXR
@@ -29,6 +30,12 @@ namespace MirageXR
 
         protected override void RegisterServices()
         {
+#if UNITY_EDITOR
+            AppLog.MinimumLogLevel = LogLevel.TRACE;
+#else
+            AppLog.MinimumLogLevel = LogLevel.INFO;
+#endif
+
             ServiceManager.RegisterService(new WorldAnchorService());
             ServiceManager.RegisterService(new KeywordService());
 

--- a/Assets/MirageXR/Common/Scripts/Sketchfab/OAuth/SketchfabOIDCProvider.cs
+++ b/Assets/MirageXR/Common/Scripts/Sketchfab/OAuth/SketchfabOIDCProvider.cs
@@ -1,8 +1,5 @@
 ﻿using i5.Toolkit.Core.Utilities;
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using UnityEngine;
 
 namespace i5.Toolkit.Core.OpenIDConnectClient
 {
@@ -10,110 +7,15 @@ namespace i5.Toolkit.Core.OpenIDConnectClient
     /// Implementation of the OpenID Connect Sketchfab Provider
     /// More information can be found here: https://sketchfab.com/developers/oauth
     /// </summary>
-    public class SketchfabOidcProvider : IOidcProvider
+    public class SketchfabOidcProvider : AbstractOidcProvider
     {
-        /// <summary>
-        /// The endpoint for the log in
-        /// </summary>
-        private const string authorizationEndpoint = "https://sketchfab.com/oauth2/authorize/";
-        /// <summary>
-        /// The end point where the access token can be requested
-        /// </summary>
-        private const string tokenEndpoint = "https://sketchfab.com/oauth2/token/";
-        /// <summary>
-        /// The end point where user information can be requested
-        /// </summary>
-        private const string userInfoEndpoint = "https://sketchfab.com/oauth2/userinfo/";
-        /// <summary>
-        /// Gets or sets the used authorization flow
-        /// </summary>
-        public AuthorizationFlow AuthorizationFlow { get; set; }
-
-        /// <summary>
-        /// Specifies how the REST API of the Web service is accessed
-        /// </summary>
-        public IRestConnector RestConnector { get; set; }
-
-        /// <summary>
-        /// Client data that are required to authorize the client at the provider
-        /// </summary>
-        public ClientData ClientData { get; set; }
-
-        /// <summary>
-        /// Serializer that is responsible for parsing JSON data and converting to JSON
-        /// </summary>
-        public IJsonSerializer JsonSerializer { get; set; }
-
-        /// <summary>
-        /// The implementation that should accesss the browser
-        /// </summary>
-        public IBrowser Browser { get; set; }
-
         /// <summary>
         /// Creates a new instance of the Sketchfab client
         /// </summary>
         public SketchfabOidcProvider()
+            : base()
         {
-            RestConnector = new UnityWebRequestRestConnector();
-            JsonSerializer = new JsonUtilityAdapter();
-            Browser = new Browser();
-        }
-
-        /// <summary>
-        /// Gets the access token based on a previously retrieved authorization code
-        /// </summary>
-        /// <param name="code">The authorization code</param>
-        /// <param name="redirectUri">The redirect URI which was used during the login</param>
-        /// <returns>Returns the access token if it could be retrieved; otherwise it returns an empty string</returns>
-        public async Task<string> GetAccessTokenFromCodeAsync(string code, string redirectUri)
-        {
-            if (ClientData == null)
-            {
-                i5Debug.LogError("No client data supplied for the OpenID Connect Client.\n" +
-                    "Initialize this provider with an OpenID Connect Data file.", this);
-                return "";
-            }
-
-            string uri = tokenEndpoint + $"?code={code}&client_id={ClientData.ClientId}" +
-                $"&client_secret={ClientData.ClientSecret}&redirect_uri={redirectUri}&grant_type=authorization_code";
-
-            WebResponse<string> response = await RestConnector.PostAsync(uri, "");
-            if (response.Successful)
-            {
-                Debug.Log("got auth response:" + response.Content);
-                SketchfabAuthorizationFlowAnswer answer =
-                    JsonSerializer.FromJson<SketchfabAuthorizationFlowAnswer>(response.Content);
-                if (answer == null)
-                {
-                    i5Debug.Log("Could not parse access token in code flow answer", this);
-                    return "";
-                }
-                return answer.access_token;
-            }
-            else
-            {
-                Debug.LogError(response.ErrorMessage + ": " + response.Content);
-                return "";
-            }
-        }
-
-        /// <summary>
-        /// Gets the access token from a list of parameters in a Web answer
-        /// </summary>
-        /// <param name="redirectParameters">The parameters of the Web answer as a dictionary</param>
-        /// <returns>Returns the access token if it exists in the parameters,
-        /// otherwise an empty string is returned</returns>
-        public string GetAccessToken(Dictionary<string, string> redirectParameters)
-        {
-            if (redirectParameters.ContainsKey("token"))
-            {
-                return redirectParameters["token"];
-            }
-            else
-            {
-                i5Debug.LogError("Redirect parameters did not contain access token", this);
-                return "";
-            }
+            serverName = "https://sketchfab.com/oauth2";
         }
 
         /// <summary>
@@ -121,7 +23,7 @@ namespace i5.Toolkit.Core.OpenIDConnectClient
         /// </summary>
         /// <param name="accessToken">The access token to authenticate the user</param>
         /// <returns>Returns information about the logged in user if the request was successful, otherwise null</returns>
-        public async Task<IUserInfo> GetUserInfoAsync(string accessToken)
+        public override async Task<IUserInfo> GetUserInfoAsync(string accessToken)
         {
             WebResponse<string> webResponse = await RestConnector.GetAsync(userInfoEndpoint + "?access_token=" + accessToken);
             if (webResponse.Successful)
@@ -138,73 +40,6 @@ namespace i5.Toolkit.Core.OpenIDConnectClient
                 i5Debug.LogError("Error fetching the user info: " + webResponse.ErrorMessage, this);
                 return default;
             }
-        }
-
-        /// <summary>
-        /// Checks if the access token is valid by checking it at the Sketchfab provider
-        /// </summary>
-        /// <param name="accessToken">The access token that should be checked</param>
-        /// <returns>True if the access token is valid, otherwise false</returns>
-        public async Task<bool> CheckAccessTokenAsync(string accessToken)
-        {
-            IUserInfo userInfo = await GetUserInfoAsync(accessToken);
-            return userInfo != null;
-        }
-
-        /// <summary>
-        /// Opens the Sketchfab login page in the system's default Web browser
-        /// </summary>
-        /// <param name="scopes">The OpenID Connect scopes that the user must agree to</param>
-        /// <param name="redirectUri">The URI to which the browser should redirect after the successful login</param>
-        public void OpenLoginPage(string[] scopes, string redirectUri)
-        {
-            if (ClientData == null)
-            {
-                i5Debug.LogError("No client data supplied for the OpenID Connect Client.\n" +
-                    "Initialize this provider with an OpenID Connect Data file.", this);
-                return;
-            }
-
-            string responseType = AuthorizationFlow == AuthorizationFlow.AUTHORIZATION_CODE ? "code" : "token";
-            //string uriScopes = UriUtils.WordArrayToSpaceEscapedString(scopes);
-            string uri = authorizationEndpoint + $"?response_type={responseType}" +
-                $"&client_id={ClientData.ClientId}&redirect_uri={redirectUri}";
-            Browser.OpenURL(uri);
-        }
-
-        /// <summary>
-        /// Extracts the authorization code from parameters of a Web answer
-        /// </summary>
-        /// <param name="redirectParameters">Parameters of a Web answer as a dictionary</param>
-        /// <returns>The authorization code if it could be found, otherwise an empty string is returned</returns>
-        public string GetAuthorizationCode(Dictionary<string, string> redirectParameters)
-        {
-            if (redirectParameters.ContainsKey("code"))
-            {
-                return redirectParameters["code"];
-            }
-            else
-            {
-                i5Debug.LogError("Redirect parameters did not contain authorization code", this);
-                return "";
-            }
-        }
-
-        /// <summary>
-        /// Checks if the provider included error messages in the parameters of a Web answer
-        /// </summary>
-        /// <param name="parameters">The parameters of a Web answer as a dictionary</param>
-        /// <param name="errorMessage">The error message that the provider included, empty if no error exists</param>
-        /// <returns>Returns true if the parameters contain an error message, otherwise false</returns>
-        public bool ParametersContainError(Dictionary<string, string> parameters, out string errorMessage)
-        {
-            if (parameters.ContainsKey("error"))
-            {
-                errorMessage = parameters["error"];
-                return true;
-            }
-            errorMessage = "";
-            return false;
         }
     }
 }

--- a/Assets/MirageXR/Common/Scripts/Sketchfab/SketchfabManager.cs
+++ b/Assets/MirageXR/Common/Scripts/Sketchfab/SketchfabManager.cs
@@ -166,13 +166,13 @@ namespace MirageXR
         /// <summary>
         /// Opens the Sketchfab model selector panel.
         /// </summary>
-        public void SketchfabLogin_Click()
+        public async void SketchfabLogin_Click()
         {
             var service = ServiceManager.GetService<OpenIDConnectService>();
             service.OidcProvider.ClientData = SketchfabDataObject.clientData;
             service.LoginCompleted += LoginCompleted;
             service.ServerListener.ListeningUri = URL;
-            service.OpenLoginPage();
+            await service.OpenLoginPageAsync();
         }
 
         /// <summary>

--- a/Assets/MirageXR/Player/Scripts/ActionListMenu/ActionListMenu.cs
+++ b/Assets/MirageXR/Player/Scripts/ActionListMenu/ActionListMenu.cs
@@ -1,4 +1,5 @@
-﻿using MirageXR;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using MirageXR;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.UI;
@@ -76,7 +77,7 @@ public class ActionListMenu : MonoBehaviour
             }
         }
 
-        Debug.Log("Action list menu start called");
+        AppLog.LogTrace("Action list menu start called");
         EventManager.OnInitUi += Init;
         EventManager.OnActivateAction += OnActivateAction;
         EventManager.OnDeactivateAction += OnDeactivateAction;

--- a/Assets/MirageXR/Player/Scripts/ActionListMenu/ActivityEditor.cs
+++ b/Assets/MirageXR/Player/Scripts/ActionListMenu/ActivityEditor.cs
@@ -1,4 +1,5 @@
-﻿using MirageXR;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using MirageXR;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -137,7 +138,7 @@ public class ActivityEditor : MonoBehaviour
 
     public void OnEditToggleChanged(bool value)
     {
-        Debug.Log("Toggle changed " + value);
+        AppLog.LogDebug("Toggle changed " + value);
         if (RootObject.Instance.activityManager != null)
         {
             RootObject.Instance.activityManager.EditModeActive = value;

--- a/Assets/MirageXR/Player/Scripts/ActivitySelection/ActivityFilter.cs
+++ b/Assets/MirageXR/Player/Scripts/ActivitySelection/ActivityFilter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -20,7 +21,7 @@ namespace MirageXR
 
         private void OnTextUpdated(string value)
         {
-            Debug.Log($"Text updated: {value}");
+            AppLog.LogDebug($"Text updated: {value}");
             if (string.IsNullOrEmpty(value))
             {
                 _sessionListView.SetAllItems();

--- a/Assets/MirageXR/Player/Scripts/ActivitySelection/SessionButton.cs
+++ b/Assets/MirageXR/Player/Scripts/ActivitySelection/SessionButton.cs
@@ -1,4 +1,5 @@
 ﻿using i5.Toolkit.Core.ServiceCore;
+using i5.Toolkit.Core.VerboseLogging;
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -25,14 +26,14 @@ namespace MirageXR
                 // show loading label
                 Loading.Instance.LoadingVisibility(true);
 
-                Debug.Log("Play activity");
+                AppLog.LogInfo("Playing activity...");
                 Play();
             }
         }
 
         private async Task DownloadAsync()
         {
-            Debug.Log("Download session");
+            AppLog.LogInfo("Downloading session...");
             // reset any error
             _selectedListViewItem.Content.HasError = false;
             // indicate that the system is working
@@ -41,7 +42,7 @@ namespace MirageXR
 
             bool success;
             Session arlemFile = _selectedListViewItem.Content.Session;
-            Debug.Log($"Downloading from {arlemFile.contextid}/{arlemFile.component}/{arlemFile.filearea}/{arlemFile.itemid}/{arlemFile.filename}");
+            AppLog.LogInfo($"Downloading from {arlemFile.contextid}/{arlemFile.component}/{arlemFile.filearea}/{arlemFile.itemid}/{arlemFile.filename}");
             using (SessionDownloader downloader = new SessionDownloader($"{DBManager.domain}/pluginfile.php/{arlemFile.contextid}/{arlemFile.component}/{arlemFile.filearea}/{arlemFile.itemid}/{arlemFile.filename}", arlemFile.sessionid + ".zip"))
             {
                 success = await downloader.DownloadZipFileAsync();
@@ -54,7 +55,7 @@ namespace MirageXR
                     }
                     catch (Exception e)
                     {
-                        Debug.LogError(e.ToString());
+                        AppLog.LogException(e);
                         success = false;
                     }
                 }

--- a/Assets/MirageXR/Player/Scripts/ActivitySelection/SessionDownloader.cs
+++ b/Assets/MirageXR/Player/Scripts/ActivitySelection/SessionDownloader.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Networking;
 using Microsoft.MixedReality.Toolkit.Utilities;
+using i5.Toolkit.Core.VerboseLogging;
 
 namespace MirageXR
 {
@@ -25,7 +26,7 @@ namespace MirageXR
             using (UnityWebRequest req = new UnityWebRequest(_downloadUrl))
             {
                 req.method = UnityWebRequest.kHttpVerbGET;
-                Debug.Log($"Downloading zip file to " + _zipFilePath);
+                AppLog.LogInfo($"Downloading zip file to " + _zipFilePath);
                 DownloadHandlerFile downloadHandler = new DownloadHandlerFile(_zipFilePath) { removeFileOnAbort = true };
                 req.downloadHandler = downloadHandler;
                 await req.SendWebRequest();
@@ -37,8 +38,8 @@ namespace MirageXR
 
         public async Task UnzipFileAsync()
         {
-            Debug.Log($"Application persistent data path is {Application.persistentDataPath}");
-            Debug.Log($"Unzipping zip file from {_zipFilePath} to {_targetFolder}");
+            AppLog.LogDebug($"Application persistent data path is {Application.persistentDataPath}");
+            AppLog.LogInfo($"Unzipping zip file from {_zipFilePath} to {_targetFolder}");
             using (Stream stream = new FileStream(_zipFilePath, FileMode.Open))
             {
                 await ZipUtilities.ExtractZipFileAsync(stream, _targetFolder);
@@ -47,10 +48,10 @@ namespace MirageXR
 
         public void Dispose()
         {
-            Debug.Log("Disposing session downloader");
+            AppLog.LogTrace("Disposing session downloader");
             if (File.Exists(_zipFilePath))
             {
-                Debug.Log($"Clean up: Deleting zip file at {_zipFilePath}");
+                AppLog.LogDebug($"Clean up: Deleting zip file at {_zipFilePath}");
                 File.Delete(_zipFilePath);
             }
         }

--- a/Assets/MirageXR/Player/Scripts/Augmentations/AudioPlayer/AudioPlayer.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/AudioPlayer/AudioPlayer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -67,14 +68,14 @@ namespace MirageXR
             // Check that url is not empty.
             if (string.IsNullOrEmpty(obj.url))
             {
-                Debug.Log("Content URL not provided.");
+                AppLog.LogWarning("Content URL not provided.");
                 return false;
             }
 
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 
@@ -351,7 +352,7 @@ namespace MirageXR
                 {
                     audioName = audioName.Substring(0, audioName.Length - 4);
                 }
-                Debug.Log("Trying to load audio: " + audioName);
+                AppLog.LogTrace("Trying to load audio: " + audioName);
                 AudioClip audioClip = Resources.Load(audioName, typeof(AudioClip)) as AudioClip;
                 audioPlayer.clip = audioClip;
                 audioPlayer.playOnAwake = false;
@@ -369,7 +370,7 @@ namespace MirageXR
                 // Local file
                 string dataPath = Application.persistentDataPath;
                 string completeAudioName = "file://" + dataPath + "/" + audioName;
-                Debug.Log("Trying to load audio: " + completeAudioName);
+                AppLog.LogTrace("Trying to load audio: " + completeAudioName);
                 WWW www = new WWW(completeAudioName);
                 yield return www;
                 AudioClip audioClip = www.GetAudioClip(false, false, AudioType.WAV);
@@ -385,7 +386,7 @@ namespace MirageXR
                 var filename = url[url.Length - 1];
 
                 var completeAudioName = "file://" + activityManager.ActivityPath + "/" + filename;
-                Debug.Log("Trying to load audio: " + completeAudioName);
+                AppLog.LogTrace("Trying to load audio: " + completeAudioName);
                 WWW www = new WWW(completeAudioName);
                 yield return www;
                 AudioClip audioClip = www.GetAudioClip(false, false, AudioType.WAV);

--- a/Assets/MirageXR/Player/Scripts/Augmentations/Detect/Detect.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/Detect/Detect.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using Microsoft.MixedReality.Toolkit.Input;
 using MirageXR;
+using i5.Toolkit.Core.VerboseLogging;
 
 namespace MirageXR
 {
@@ -65,7 +66,7 @@ namespace MirageXR
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 

--- a/Assets/MirageXR/Player/Scripts/Augmentations/DrawingPlayer/DrawingPlayer.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/DrawingPlayer/DrawingPlayer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -86,14 +87,14 @@ namespace MirageXR
             // Check that url is not empty.
             if (string.IsNullOrEmpty(obj.url))
             {
-                Debug.Log("Content URL not provided.");
+                AppLog.LogWarning("Content URL not provided.");
                 return false;
             }
 
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 
@@ -147,7 +148,7 @@ namespace MirageXR
             }
             catch (Exception e)
             {
-                Debug.Log("An error occured during import of drawing file. Aborting. Error: " + e.Message);
+                AppLog.LogError("An error occured during import of drawing file. Aborting. Error: " + e.Message);
                 return false;
             }
         }

--- a/Assets/MirageXR/Player/Scripts/Augmentations/Glyph/GlyphItems.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/Glyph/GlyphItems.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.MixedReality.Toolkit.UI.BoundsControl;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using Microsoft.MixedReality.Toolkit.UI.BoundsControl;
 using UnityEngine;
 
 namespace MirageXR
@@ -45,7 +46,7 @@ namespace MirageXR
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 

--- a/Assets/MirageXR/Player/Scripts/Augmentations/ImageViewer/FloatingImageViewer.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/ImageViewer/FloatingImageViewer.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.MixedReality.Toolkit.UI.BoundsControl;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using Microsoft.MixedReality.Toolkit.UI.BoundsControl;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -48,14 +49,14 @@ namespace MirageXR
             // Check that url is not empty.
             if (string.IsNullOrEmpty(obj.url))
             {
-                Debug.Log("Content URL not provided.");
+                AppLog.LogWarning("Content URL not provided.");
                 return false;
             }
 
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 
@@ -153,7 +154,7 @@ namespace MirageXR
             {
                 if (!imageName.Contains('/'))
                 {
-                    Debug.LogError($"Can't parse file name '{imageName}'");
+                    AppLog.LogError($"Can't parse file name '{imageName}'");
                 }
 
                 var fileName = imageName.Split('/').LastOrDefault();
@@ -166,7 +167,7 @@ namespace MirageXR
 
             if (!File.Exists(path))
             {
-                Debug.LogError($"File {path} doesn't exists");
+                AppLog.LogError($"File {path} doesn't exists");
                 return;
             }
 

--- a/Assets/MirageXR/Player/Scripts/Augmentations/ImageViewer/StaticImageViewer.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/ImageViewer/StaticImageViewer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -31,7 +32,7 @@ namespace MirageXR
             {
                 string dataPath = Application.persistentDataPath;
                 string completeImageName = "file://" + dataPath + "/" + ImageName;
-                Debug.Log("Trying to load static image from:" + completeImageName);
+                AppLog.LogTrace("Trying to load static image from:" + completeImageName);
                 WWW www = new WWW(completeImageName);
                 yield return www;
                 Texture2D imageTex = new Texture2D(4, 4, TextureFormat.DXT1, false);
@@ -46,7 +47,7 @@ namespace MirageXR
 
                 var completeImageName = $"file://{RootObject.Instance.activityManager.ActivityPath}/{filename}";
 
-                Debug.Log("Trying to load image from:" + completeImageName);
+                AppLog.LogTrace("Trying to load image from:" + completeImageName);
 
                 WWW www = new WWW(completeImageName);
                 yield return www;

--- a/Assets/MirageXR/Player/Scripts/Augmentations/Label/Label.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/Label/Label.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.MixedReality.Toolkit.UI;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using Microsoft.MixedReality.Toolkit.UI;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -26,14 +27,14 @@ namespace MirageXR
             // Check if the label text is set.
             if (string.IsNullOrEmpty(obj.text))
             {
-                Debug.Log("Label text not provided.");
+                AppLog.LogWarning("Label text not provided.");
                 return false;
             }
 
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 

--- a/Assets/MirageXR/Player/Scripts/Augmentations/Model/ButtonHandler.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/Model/ButtonHandler.cs
@@ -1,4 +1,5 @@
 ﻿
+using i5.Toolkit.Core.VerboseLogging;
 using System;
 using System.Collections;
 using UnityEngine;
@@ -46,7 +47,7 @@ public class ButtonHandler : MonoBehaviour
         }
         else
         {
-            Debug.Log("Resource url was not parsable");
+            AppLog.LogWarning("Resource url was not parsable");
         }
     }
 

--- a/Assets/MirageXR/Player/Scripts/Augmentations/Model/Model.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/Model/Model.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using UnityEngine;
 using Siccity.GLTFUtility;
+using i5.Toolkit.Core.VerboseLogging;
 
 namespace MirageXR
 {
@@ -60,14 +61,14 @@ namespace MirageXR
             // Check that url is not empty.
             if (string.IsNullOrEmpty(obj.url))
             {
-                Debug.Log("Content URL not provided.");
+                AppLog.LogWarning("Content URL not provided.");
                 return false;
             }
 
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 
@@ -92,7 +93,7 @@ namespace MirageXR
             startLoadTime = Time.time;
             var loadPath = Path.Combine(RootObject.Instance.activityManager.ActivityPath, obj.option, "scene.gltf");
 
-            Debug.Log($"Loading model: {loadPath}");
+            AppLog.LogTrace($"Loading model: {loadPath}");
 
             Importer.ImportGLTFAsync(loadPath, new ImportSettings(), OnFinishLoadingAsync);
         }
@@ -105,7 +106,7 @@ namespace MirageXR
                 return;
             }
 
-            Debug.Log($"Imported {model.name} in {Time.time - startLoadTime} seconds");
+            AppLog.LogTrace($"Imported {model.name} in {Time.time - startLoadTime} seconds");
 
             var startPos = transform.position + transform.forward * -0.5f + transform.up * -0.1f;
 
@@ -131,7 +132,7 @@ namespace MirageXR
 
             if (clip.Length > 0)
             {
-                Debug.Log($"Animation(s) found ({clip.Length})...isLegacy? {clip[0].legacy}");
+                AppLog.LogDebug($"Animation(s) found ({clip.Length})...isLegacy? {clip[0].legacy}");
 
                 animation = model.AddComponent<Animation>();
                 animation.AddClip(clip[0], "leaning");
@@ -228,7 +229,7 @@ namespace MirageXR
                 }
             }
 
-            Debug.Log($"largest collider: {largestColliderIndex} ({colliderSize.ToString("F4")})");
+            AppLog.LogDebug($"largest collider: {largestColliderIndex} ({colliderSize.ToString("F4")})");
 
             // set magnification and translation factors based on gltf info.
             float magnificationFactor = 0.5f / colliderSize.magnitude;
@@ -250,7 +251,7 @@ namespace MirageXR
             }
 
             myPoiEditor.ModelMagnification = magnificationFactor;
-            Debug.Log($"{modelToAdjust.name} has file mag. factor {magnificationFactor:F4}");
+            AppLog.LogDebug($"{modelToAdjust.name} has file mag. factor {magnificationFactor:F4}");
 
             modelToAdjust.transform.localScale *= myPoiEditor.ModelMagnification;
             modelToAdjust.transform.localPosition = Vector3.zero;
@@ -267,7 +268,7 @@ namespace MirageXR
 
             if (Directory.Exists(modelFolderPath))
             {
-                Debug.Log("found model folder (" + modelFolderPath + "). Deleting...");
+                AppLog.LogTrace("found model folder (" + modelFolderPath + "). Deleting...");
                 Utilities.DeleteAllFilesInDirectory(modelFolderPath);
                 Directory.Delete(modelFolderPath);
             }

--- a/Assets/MirageXR/Player/Scripts/Augmentations/Plugin/PluginController.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/Plugin/PluginController.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using UnityEngine;
 
 namespace MirageXR
 {
@@ -27,7 +28,7 @@ namespace MirageXR
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 
@@ -46,8 +47,7 @@ namespace MirageXR
 
         private void loadPlugin(string path)
         {
-
-            Debug.Log(path);
+            AppLog.LogTrace($"Loading plugin from path {path}");
             plugin = Instantiate(Resources.Load<GameObject>(path), Vector3.zero, Quaternion.identity);
 
             plugin.transform.parent = gameObject.transform; // pluginParent;

--- a/Assets/MirageXR/Player/Scripts/Augmentations/Plugin/PluginEditor.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/Plugin/PluginEditor.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -66,7 +67,7 @@ namespace MirageXR
                 var rect = new Rect(0, 0, pluginTex.width, pluginTex.height);
                 var pivot = new Vector2(0.5f, 0.5f);
 
-                Debug.Log("Plugin Name: " + plugin.name);
+                AppLog.LogDebug("Plugin Name: " + plugin.name);
 
                 var icon = Instantiate(iconPrefab, Vector3.zero, Quaternion.identity);
                 icon.transform.FindDeepChild("Image").GetComponent<Image>().sprite = Sprite.Create(pluginTex, rect, pivot);
@@ -107,7 +108,7 @@ namespace MirageXR
             _action.appIDs.Add(plugin.id);
 
 
-            Debug.Log("ACTION ID = " + _annotationToEdit.url);
+            AppLog.LogDebug("ACTION ID = " + _annotationToEdit.url);
 
             EventManager.ActivateObject(_annotationToEdit);
             EventManager.NotifyActionModified(_action);

--- a/Assets/MirageXR/Player/Scripts/Augmentations/PostIt/PostItLabel.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/PostIt/PostItLabel.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.MixedReality.Toolkit.UI;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using Microsoft.MixedReality.Toolkit.UI;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -24,14 +25,14 @@ namespace MirageXR
             // Check if the label text is set.
             if (string.IsNullOrEmpty(obj.text))
             {
-                Debug.Log("Label text not provided.");
+                AppLog.LogWarning("Label text not provided.");
                 return false;
             }
 
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 

--- a/Assets/MirageXR/Player/Scripts/Augmentations/Potentiometer/Potentiometer.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/Potentiometer/Potentiometer.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.MixedReality.Toolkit.UI;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using Microsoft.MixedReality.Toolkit.UI;
 using UnityEngine;
 
 namespace MirageXR
@@ -10,19 +11,19 @@ namespace MirageXR
             // Check that all the sensor related crap is defined.
             if (string.IsNullOrEmpty(obj.sensor))
             {
-                Debug.Log("Sensor is not defined.");
+                AppLog.LogWarning("Sensor is not defined.");
                 return false;
             }
 
             if (string.IsNullOrEmpty(obj.key))
             {
-                Debug.Log("Sensor key is not defined.");
+                AppLog.LogWarning("Sensor key is not defined.");
                 return false;
             }
 
             if (string.IsNullOrEmpty(obj.option))
             {
-                Debug.Log("Sensor option string is not defined.");
+                AppLog.LogWarning("Sensor option string is not defined.");
                 return false;
             }
 
@@ -30,20 +31,20 @@ namespace MirageXR
 
             if (limits.Length != 2)
             {
-                Debug.Log("Sensor limits not properly set.");
+                AppLog.LogWarning("Sensor limits not properly set.");
                 return false;
             }
 
             if (!float.TryParse(limits[0], out float min))
             {
-                Debug.Log("Minimum value is not a float.");
+                AppLog.LogWarning("Minimum value is not a float.");
                 return false;
             }
 
 
             if (!float.TryParse(limits[1], out float max))
             {
-                Debug.Log("Maximum value is not a float.");
+                AppLog.LogWarning("Maximum value is not a float.");
                 return false;
             }
 
@@ -51,14 +52,14 @@ namespace MirageXR
 
             if (!controller.AttachStream(obj.sensor, obj.key, min, max))
             {
-                Debug.Log("Couldn't attach sensor stream.");
+                AppLog.LogWarning("Couldn't attach sensor stream.");
                 return false;
             }
 
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 

--- a/Assets/MirageXR/Player/Scripts/Augmentations/Symbol/Symbol.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/Symbol/Symbol.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.MixedReality.Toolkit.UI;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using Microsoft.MixedReality.Toolkit.UI;
 using UnityEngine;
 
 namespace MirageXR
@@ -18,7 +19,7 @@ namespace MirageXR
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 
@@ -39,7 +40,7 @@ namespace MirageXR
             // If symbol couldn't be found, terminate initialization.
             if (symbol == null)
             {
-                Debug.Log("Symbol couldn't be found. " + obj.predicate);
+                AppLog.LogWarning("Symbol couldn't be found. " + obj.predicate);
                 return false;
             }
 
@@ -60,7 +61,7 @@ namespace MirageXR
                 {
                     // If the animation type is unknown, terminate the initialization.
                     default:
-                        Debug.Log("Unknown animation type. " + animationId);
+                        AppLog.LogWarning("Unknown animation type. " + animationId);
                         return false;
 
                     // For rotation types.

--- a/Assets/MirageXR/Player/Scripts/Augmentations/UiSymbol/UiSymbol.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/UiSymbol/UiSymbol.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -26,7 +27,7 @@ namespace MirageXR
             // If symbol couldn't be found, terminate initialization.
             if (symbol == null)
             {
-                Debug.Log("Symbol couldn't be found. " + content.predicate);
+                AppLog.LogWarning("Symbol couldn't be found. " + content.predicate);
                 return false;
             }
 

--- a/Assets/MirageXR/Player/Scripts/Augmentations/VideoViewer/FloatingVideoViewer.cs
+++ b/Assets/MirageXR/Player/Scripts/Augmentations/VideoViewer/FloatingVideoViewer.cs
@@ -1,4 +1,5 @@
 ﻿using i5.Toolkit.Core.ServiceCore;
+using i5.Toolkit.Core.VerboseLogging;
 using System.Collections;
 using System.IO;
 using UnityEngine;
@@ -93,7 +94,7 @@ namespace MirageXR
             // Check that url is not empty.
             if (string.IsNullOrEmpty(content.url))
             {
-                Debug.Log("Content URL not provided.");
+                AppLog.LogWarning("Content URL not provided.");
                 return false;
             }
 

--- a/Assets/MirageXR/Player/Scripts/Behaviours/DeviceMqttBehaviour.cs
+++ b/Assets/MirageXR/Player/Scripts/Behaviours/DeviceMqttBehaviour.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using MirageXR;
 using Microsoft.MixedReality.Toolkit.Utilities.Solvers;
+using i5.Toolkit.Core.VerboseLogging;
 
 public class DeviceMqttBehaviour : MonoBehaviour
 {
@@ -105,7 +106,7 @@ public class DeviceMqttBehaviour : MonoBehaviour
             try
             {
                 await _mqtt.ConnectAsync(url, port, _sensor.username, _sensor.password, clientId);
-                Debug.Log(_sensor.id + " connected.");
+                AppLog.LogInfo(_sensor.id + " connected.");
             }
             catch
             {
@@ -119,7 +120,7 @@ public class DeviceMqttBehaviour : MonoBehaviour
             try
             {
                 await _mqtt.ConnectAsync(url, port, _sensor.username, _sensor.password, clientId);
-                Debug.Log(_sensor.id + " connected.");
+                AppLog.LogInfo(_sensor.id + " connected.");
             }
             catch
             {
@@ -149,7 +150,7 @@ public class DeviceMqttBehaviour : MonoBehaviour
 
     private async void ConnectionEstablishedRoutine()
     {
-        Debug.Log("Connection established.");
+        AppLog.LogInfo("Connection established.");
         // Instantiate a sensor container.
 
         // _sensorDisplay.name = _sensor.id;

--- a/Assets/MirageXR/Player/Scripts/Behaviours/HumEnvMqttBehaviour.cs
+++ b/Assets/MirageXR/Player/Scripts/Behaviours/HumEnvMqttBehaviour.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using i5.Toolkit.Core.VerboseLogging;
 using MQTT;
 using UnityEngine;
 
@@ -57,7 +58,7 @@ namespace MirageXR
         {
             _sensor = sensor;
 
-            Debug.Log("Starting connection to sensors...");
+            AppLog.LogTrace("Starting connection to sensors...");
 
             // Generate randomized client id.
             var clientId = "WEKIT-";
@@ -67,7 +68,7 @@ namespace MirageXR
 
             if (!fullUri.StartsWith("mqtt://"))
             {
-                Debug.Log("Tried to create sensor without mqtt connection: " + _sensor.id);
+                AppLog.LogWarning("Tried to create sensor without mqtt connection: " + _sensor.id);
                 return false;
             }
 
@@ -78,7 +79,7 @@ namespace MirageXR
 
             if (uriComponents.Length != 2)
             {
-                Debug.Log("Sensor uri doesn't contain proper url + port definition: " + _sensor.id);
+                AppLog.LogWarning("Sensor uri doesn't contain proper url + port definition: " + _sensor.id);
                 return false;
             }
 
@@ -89,7 +90,7 @@ namespace MirageXR
             {
                 if (string.IsNullOrEmpty(_sensor.password))
                 {
-                    Debug.Log("Sensor connection username without a password: " + _sensor.id);
+                    AppLog.LogWarning("Sensor connection username without a password: " + _sensor.id);
                     return false;
                 }
 

--- a/Assets/MirageXR/Player/Scripts/Character Aug/CharacterController.cs
+++ b/Assets/MirageXR/Player/Scripts/Character Aug/CharacterController.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using Microsoft.MixedReality.Toolkit.UI;
 using Microsoft.MixedReality.Toolkit.UI.BoundsControl;
+using i5.Toolkit.Core.VerboseLogging;
 
 namespace MirageXR
 {
@@ -135,7 +136,7 @@ namespace MirageXR
             // Try to set the parent and if it fails, terminate initialization.
             if (!SetParent(obj))
             {
-                Debug.Log("Couldn't set the parent.");
+                AppLog.LogWarning("Couldn't set the parent.");
                 return false;
             }
 
@@ -902,7 +903,7 @@ namespace MirageXR
 
             if (animationMenu.value >= animationMenu.options.Count || animationMenu.value < 0)
             {
-                Debug.LogError("animationMenu.options: out of range");
+                AppLog.LogError("animationMenu.options: out of range");
                 return;
             }
             var clipName = animationMenu.options[animationMenu.value].text;
@@ -1094,7 +1095,7 @@ namespace MirageXR
             if (character.steps.Count == 0)
             {
                 gameObject.SetActive(false);
-                Debug.LogError("The character augmentation has had a major change. Please recreate the existing characters.");
+                AppLog.LogError("The character augmentation has had a major change. Please recreate the existing characters.");
                 return false;
             }
 
@@ -1325,7 +1326,7 @@ namespace MirageXR
             }
             catch (NullReferenceException e)
             {
-                Debug.LogError($"Some references are missing on display image animation part. f.exp imageContainer,MyImageAnnotation ,etc. {e}");
+                AppLog.LogError($"Some references are missing on display image animation part. f.exp imageContainer,MyImageAnnotation ,etc. {e}");
             }
 
         }

--- a/Assets/MirageXR/Player/Scripts/IBMWatson/DaimonManager.cs
+++ b/Assets/MirageXR/Player/Scripts/IBMWatson/DaimonManager.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -38,7 +39,7 @@ public class DaimonManager : MonoBehaviour
     {
         yield return new WaitForSeconds(preDelay);
 
-        Debug.Log("Look=" + "LEFT/RIGHT");
+        AppLog.LogTrace("Look=" + "LEFT/RIGHT");
         yield return new WaitForSeconds(duration);
 
     }
@@ -58,7 +59,7 @@ public class DaimonManager : MonoBehaviour
         {
 
             //check that clip is not playing
-            Debug.Log("-------------------- Speech Output has finished playing, now reactivating SpeechInput.");
+            AppLog.LogInfo("-------------------- Speech Output has finished playing, now reactivating SpeechInput.");
             check = false;
 
             if (triggerNext)

--- a/Assets/MirageXR/Player/Scripts/IBMWatson/DialogueService.cs
+++ b/Assets/MirageXR/Player/Scripts/IBMWatson/DialogueService.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using IBM.Cloud.SDK;
 using IBM.Cloud.SDK.Utilities;
 using IBM.Watson.Assistant.V2;
@@ -110,7 +111,7 @@ public class DialogueService : MonoBehaviour
 
     private IEnumerator CreateSession()
     {
-        Debug.Log("CONNECTING TO ASSISTANT: " + assistantId);
+        AppLog.LogInfo("CONNECTING TO ASSISTANT: " + assistantId);
         service.CreateSession(OnCreateSession, assistantId);
 
         while (!createSessionTested)
@@ -128,7 +129,7 @@ public class DialogueService : MonoBehaviour
 
     public void SendMessageToAssistant(string theText)
     {
-        Debug.Log("Sending to assistant service: " + theText);
+        AppLog.LogDebug("Sending to assistant service: " + theText);
         if (createSessionTested)
         {
             service.Message(OnResponseReceived, assistantId, sessionId, input: new MessageInput()
@@ -144,7 +145,7 @@ public class DialogueService : MonoBehaviour
         }
         else
         {
-            Debug.Log("WARNING: trying to SendMessageToAssistant before session is established.");
+            AppLog.LogWarning("trying to SendMessageToAssistant before session is established.");
         }
 
     }
@@ -162,14 +163,14 @@ public class DialogueService : MonoBehaviour
 
         if (response.Result.Output.Generic != null && response.Result.Output.Generic.Count > 0)
         {
-            Debug.Log("DialogueService response: " + response.Result.Output.Generic[0].Text);
-            if (response.Result.Output.Intents.Capacity > 0) Debug.Log("    -> " + response.Result.Output.Intents[0].Intent.ToString());
+            AppLog.LogDebug("DialogueService response: " + response.Result.Output.Generic[0].Text);
+            if (response.Result.Output.Intents.Capacity > 0) AppLog.LogDebug("    -> " + response.Result.Output.Intents[0].Intent.ToString());
         }
 
         // check if Watson was able to make sense of the user input, otherwise ask to repeat the input
         if (response.Result.Output.Intents == null && response.Result.Output.Actions == null)
         {
-            Debug.Log("I did not understand");
+            AppLog.LogDebug("I did not understand");
             dSpeechOutputMgr.Speak("I don't understand, can you rephrase?");
 
         }
@@ -194,7 +195,7 @@ public class DialogueService : MonoBehaviour
                         break;
                     case "name":
                         username = response.Result.Output.Entities.Find((x) => x.Entity.ToString() == "sys-person").Value.ToString();
-                        Debug.Log("username = " + username);
+                        AppLog.LogDebug("username = " + username);
                         break;
                     default:
                         break;
@@ -205,13 +206,13 @@ public class DialogueService : MonoBehaviour
             if (response.Result.Output.Actions != null && response.Result.Output.Actions.Count > 0)
             {
                 string actionName = response.Result.Output.Actions[0].Name;
-                Debug.Log("Action Name = " + actionName);
+                AppLog.LogDebug("Action Name = " + actionName);
                 // check whether it is really the intent we want to check
                 // (or do we want to know the name of the dialogue step?)
                 switch (actionName)
                 {
                     case "jump to":
-                        Debug.Log("Jump to action recieved");
+                        AppLog.LogTrace("Jump to action recieved");
                         break;
                     default:
                         break;
@@ -249,7 +250,7 @@ public class DialogueService : MonoBehaviour
                 {
                     dAImgr.check = true;
                     dSpeechOutputMgr.Speak("I don't understand, can you rephrase?");
-                    Debug.LogError($"Somthing went wrong but the conversiontion will be continued. The error is:\n {e}");
+                    AppLog.LogError($"Somthing went wrong but the conversiontion will be continued. The error is:\n {e}");
                 }
 
             }
@@ -363,10 +364,10 @@ public class DialogueService : MonoBehaviour
     public void OnDestroy()
     {
 
-        Debug.Log("DialogueService: deregestering callback for speech2text input");
+        AppLog.LogTrace("DialogueService: deregestering callback for speech2text input");
         dSpeechInputMgr.onInputReceived -= OnInputReceived;
 
-        Debug.Log("DialogueService: Attempting to delete session");
+        AppLog.LogTrace("DialogueService: Attempting to delete session");
         service.DeleteSession(OnDeleteSession, assistantId, sessionId);
 
     }

--- a/Assets/MirageXR/Player/Scripts/IBMWatson/SpeechOutputService.cs
+++ b/Assets/MirageXR/Player/Scripts/IBMWatson/SpeechOutputService.cs
@@ -10,8 +10,7 @@ using IBM.Watson.TextToSpeech.V1;
 using IBM.Cloud.SDK.Connection;
 using IBM.Cloud.SDK.DataTypes;
 using System;
-
-
+using i5.Toolkit.Core.VerboseLogging;
 
 public class SpeechOutputService : MonoBehaviour
 {
@@ -69,7 +68,7 @@ public class SpeechOutputService : MonoBehaviour
 
     public void Speak(string text)
     {
-        Debug.Log("Sending to Watson to generate voice audio output: " + text);
+        AppLog.LogTrace("Sending to Watson to generate voice audio output: " + text);
         if (text != null && text != "")
         {
             myService.Synthesize(
@@ -81,7 +80,7 @@ public class SpeechOutputService : MonoBehaviour
         }
         else
         {
-            Debug.Log("WARNING: text to speech: text was empty");
+            AppLog.LogWarning("Text to speech: text was empty");
         }
 
     }
@@ -93,7 +92,7 @@ public class SpeechOutputService : MonoBehaviour
         AudioClip clip = null;
         synthesizeResponse = response.Result;
         clip = WaveFile.ParseWAV("myClip", synthesizeResponse);
-        Debug.Log("before playing: " + clip);
+        AppLog.LogDebug("before playing: " + clip);
         PlayClip(clip);
     }
 
@@ -114,12 +113,12 @@ public class SpeechOutputService : MonoBehaviour
 
             dDaimonMgr.wait = clip.length; // may be useful to add +0.5f
             dDaimonMgr.check = true;
-            Debug.Log("Speech output playing, set DaimonMgr waiting time for SpeechInput to reactivate again (when done) after " + clip.length + " seconds");
+            AppLog.LogDebug("Speech output playing, set DaimonMgr waiting time for SpeechInput to reactivate again (when done) after " + clip.length + " seconds");
 
         }
         else
         {
-            Debug.Log("ERROR: something is already playing or we did not get a clip.");
+            AppLog.LogError("Something is already playing or we did not get a clip.");
         }
     }
 

--- a/Assets/MirageXR/Player/Scripts/Managers/Activity/ActivityManager.cs
+++ b/Assets/MirageXR/Player/Scripts/Managers/Activity/ActivityManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -194,7 +195,7 @@ namespace MirageXR
                 }
                 catch (Exception e)
                 {
-                    Debug.Log(e);
+                    AppLog.LogException(e);
                 }
                 _isSwitching = false;
                 EventManager.DebugLog($"Activity manager: Starting Activity: {_activity.id}");
@@ -231,7 +232,7 @@ namespace MirageXR
                 catch (Exception e)
                 {
                     Maggie.Error();
-                    Debug.LogError(e);
+                    AppLog.LogException(e);
                 }
             }
         }
@@ -283,7 +284,7 @@ namespace MirageXR
             {
                 Maggie.Error();
                 EventManager.DebugLog($"Error: Activity manager: Couldn't activate action: {id}.");
-                Debug.LogError(e);
+                AppLog.LogException(e);
             }
         }
 
@@ -579,7 +580,7 @@ namespace MirageXR
             {
                 Maggie.Error();
                 EventManager.DebugLog($"Error: Activity manager: Couldn't force start action: {id}.");
-                Debug.Log(e);
+                AppLog.LogException(e);
                 throw;
             }
         }
@@ -666,7 +667,7 @@ namespace MirageXR
             _activity.start = newAction.id;
             _activity.actions.Insert(0, newAction);
 
-            Debug.Log($"Added {newAction.id} to list of task stations");
+            AppLog.LogDebug($"Added {newAction.id} to list of task stations");
 
             RegenerateActionsList();
             await ActivateNextAction();
@@ -722,7 +723,7 @@ namespace MirageXR
                 }
                 else
                 {
-                    Debug.LogError("Could not identify the active action");
+                    AppLog.LogError("Could not identify the active action");
                 }
 
                 //Save augmentations extra data(character, pick&place,...) for be carried over to the new action if the augmentation exists in that action
@@ -735,7 +736,7 @@ namespace MirageXR
 
             _activity.actions.Insert(indexOfActive + 1, newAction);
 
-            Debug.Log($"Added {newAction.id} to list of task stations");
+            AppLog.LogDebug($"Added {newAction.id} to list of task stations");
 
             RegenerateActionsList();
             await ActivateNextAction();
@@ -780,17 +781,17 @@ namespace MirageXR
 
             if (indexToDelete < 0)
             {
-                Debug.LogError($"Could not remove {idToDelete} since the id could not be found in the list of actions");
+                AppLog.LogError($"Could not remove {idToDelete} since the id could not be found in the list of actions");
                 return;
             }
 
             int totalNumberOfActions = _activity.actions.Count;
 
-            Debug.Log($"Planning to delete action with index {indexToDelete}");
+            AppLog.LogInfo($"Deleting action with index {indexToDelete}...");
 
             if (indexToDelete == totalNumberOfActions - 1) // if deleting the last action
             {
-                Debug.Log("deleting last action");
+                AppLog.LogTrace("deleting last action");
 
                 if (totalNumberOfActions != 1)
                 {
@@ -802,7 +803,7 @@ namespace MirageXR
             }
             else if (indexToDelete == 0) // if deleting the first action
             {
-                Debug.Log("deleting first action");
+                AppLog.LogTrace("deleting first action");
                 // update start action with the one that is currently second (prior to deleting the action, in this case)
                 if (totalNumberOfActions > 1)
                 {

--- a/Assets/MirageXR/Player/Scripts/Managers/DebugManager.cs
+++ b/Assets/MirageXR/Player/Scripts/Managers/DebugManager.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using UnityEngine;
 using UnityEngine.UI;
 
 namespace MirageXR
@@ -28,12 +29,12 @@ namespace MirageXR
         {
             if (DebugText == null)
             {
-                Debug.Log("Debug manager error: Debug text not found. Please add one in editor.");
+                AppLog.LogError("Debug manager error: Debug text not found. Please add one in editor.");
             }
 
             if (DeviceInfo == null)
             {
-                Debug.Log("Debug manager error: Device info text not found. Please add one in editor.");
+                AppLog.LogError("Debug manager error: Device info text not found. Please add one in editor.");
             }
 
             DeviceInfo.text = SystemInfo.deviceUniqueIdentifier;

--- a/Assets/MirageXR/Player/Scripts/Managers/EventManager.cs
+++ b/Assets/MirageXR/Player/Scripts/Managers/EventManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System;
 using UnityEngine;
 
 namespace MirageXR
@@ -196,7 +197,7 @@ namespace MirageXR
         /// <param name="debug">Debug message.</param>
         public static void DebugLog(string debug)
         {
-            Debug.Log(debug);
+            AppLog.LogInfo(debug);
             OnDebugLog?.Invoke(debug);
         }
 
@@ -295,7 +296,7 @@ namespace MirageXR
 
         public static void InitUi()
         {
-            Debug.Log("Init UI invoked");
+            AppLog.LogTrace("Init UI invoked");
             OnInitUi?.Invoke();
         }
 
@@ -537,7 +538,7 @@ namespace MirageXR
         {
             OnActivityLoadedStamp?.Invoke(deviceId, activityId, timestamp);
 
-            Debug.Log($"LOADED STAMP: {deviceId}, {activityId}, {timestamp}");
+            AppLog.LogInfo($"LOADED STAMP: {deviceId}, {activityId}, {timestamp}");
         }
 
         public delegate void ActivityCompletedStampDelegate(string deviceId, string activityId, string timestamp);
@@ -548,7 +549,7 @@ namespace MirageXR
         {
             OnActivityCompletedStamp?.Invoke(deviceId, activityId, timestamp);
 
-            Debug.Log($"COMPLETED STAMP: {deviceId}, {activityId}, {timestamp}");
+            AppLog.LogInfo($"COMPLETED STAMP: {deviceId}, {activityId}, {timestamp}");
         }
 
         public delegate void StepActivatedStampDelegate(string deviceId, Action activatedAction, string timestamp);
@@ -559,7 +560,7 @@ namespace MirageXR
         {
             OnStepActivatedStamp?.Invoke(deviceId, activatedAction, timestamp);
 
-            Debug.Log($"ACTIVATED STAMP: {deviceId}, {activatedAction.id}, {timestamp}");
+            AppLog.LogInfo($"ACTIVATED STAMP: {deviceId}, {activatedAction.id}, {timestamp}");
         }
 
         public delegate void StepDeactivatedStampDelegate(string deviceId, Action deactivatedAction, string timestamp);
@@ -570,7 +571,7 @@ namespace MirageXR
         {
             OnStepDeactivatedStamp?.Invoke(deviceId, deactivatedAction, timestamp);
 
-            Debug.Log("DEACTIVATED STAMP: " + deviceId + ", " + deactivatedAction.id + ", " + timestamp);
+            AppLog.LogInfo("DEACTIVATED STAMP: " + deviceId + ", " + deactivatedAction.id + ", " + timestamp);
         }
 
         public delegate void ShowActivitySelectionMenuDelegate();

--- a/Assets/MirageXR/Player/Scripts/Managers/ObjectFactory.cs
+++ b/Assets/MirageXR/Player/Scripts/Managers/ObjectFactory.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.MixedReality.Toolkit.UI.BoundsControl;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using Microsoft.MixedReality.Toolkit.UI.BoundsControl;
 using System.IO;
 using UnityEngine;
 using UnityEngine.AI;
@@ -241,7 +242,7 @@ namespace MirageXR
                             // Ghost hands type.
                             case "hands":
                                 if (isActivating)
-                                    Debug.Log("hands activated");
+                                    AppLog.LogInfo("hands activated");
                                 // ActivatePrefab("HandsPrefab", obj);
                                 // else
                                 //  DestroyPrefab(obj);

--- a/Assets/MirageXR/Player/Scripts/Managers/PlatformManager.cs
+++ b/Assets/MirageXR/Player/Scripts/Managers/PlatformManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.XR.ARFoundation;
@@ -148,7 +149,7 @@ namespace MirageXR
             var screenHeight = Screen.height / Screen.dpi;
             var diagonalInches = Mathf.Sqrt(Mathf.Pow(screenWidth, 2) + Mathf.Pow(screenHeight, 2));
 
-            Debug.Log("Getting device inches: " + diagonalInches);
+            AppLog.LogDebug("Getting device inches: " + diagonalInches);
 
             return diagonalInches;
         }

--- a/Assets/MirageXR/Player/Scripts/Managers/TutorialManager.cs
+++ b/Assets/MirageXR/Player/Scripts/Managers/TutorialManager.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -95,7 +96,7 @@ namespace MirageXR
         {
             if (Instance != null)
             {
-                Debug.LogError($"{Instance.GetType().FullName} must only be a single copy!");
+                AppLog.LogError($"{Instance.GetType().FullName} must only be a single copy!");
                 return;
             }
 
@@ -160,7 +161,7 @@ namespace MirageXR
             }
             else
             {
-                Debug.LogError("Tried to start unknown tutorial type.");
+                AppLog.LogError("Tried to start unknown tutorial type.");
             }
         }
 

--- a/Assets/MirageXR/Player/Scripts/Managers/Workplace/WorkplaceManager.cs
+++ b/Assets/MirageXR/Player/Scripts/Managers/Workplace/WorkplaceManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -107,7 +108,7 @@ namespace MirageXR
 
         private async Task PerformEditModeCalibration()
         {
-            Debug.Log("Edit Mode Calibration started.\n");
+            AppLog.LogInfo("Edit Mode Calibration started.\n");
 
             foreach (var pair in calibrationPairs)
             {
@@ -134,17 +135,17 @@ namespace MirageXR
                 Object.Destroy(calibrationGuide);
             }
 
-            Debug.Log("Edit mode calibration completed.");
+            AppLog.LogInfo("Edit mode calibration completed.");
         }
 
         // here we are writing anchors for calibration pairs that (must) already exist, relative to a calibration origin.
         private async Task PerformPlayModeCalibration(Transform calibrationRoot)
         {
-            Debug.Log("Play Mode Calibration started.\n");
+            AppLog.LogInfo("Play Mode Calibration started.\n");
 
             foreach (var pair in calibrationPairs)
             {
-                Debug.Log("Handling " + pair.DetectableConfiguration.id);
+                AppLog.LogDebug("Handling " + pair.DetectableConfiguration.id);
 
                 // Create a temporary empty frame.
                 var dummy = new GameObject("AnchorDummy");
@@ -176,7 +177,7 @@ namespace MirageXR
                 pair.AnchorFrame.transform.SetParent(detectableContainer);
 
                 // Now attach anchor to the detectable anchor frame.
-                Debug.Log($"Anchor {pair.AnchorFrame.name} created at {pair.AnchorFrame.transform.position} || {pair.AnchorFrame.transform.eulerAngles}.");
+                AppLog.LogInfo($"Anchor {pair.AnchorFrame.name} created at {pair.AnchorFrame.transform.position} || {pair.AnchorFrame.transform.eulerAngles}.");
 
                 // Destroy dummy.
                 Object.Destroy(dummy);
@@ -192,7 +193,7 @@ namespace MirageXR
                 Object.Destroy(calibrationGuide);
             }
 
-            Debug.Log("Play mode calibration completed.");
+            AppLog.LogInfo("Play mode calibration completed.");
         }
 
         public Place GetPlaceFromTaskStationId(string id)
@@ -265,7 +266,7 @@ namespace MirageXR
             }
             catch (Exception e)
             {
-                Debug.LogError(e);
+                Debug.LogException(e);
             }
         }
 

--- a/Assets/MirageXR/Player/Scripts/Managers/Workplace/WorkplaceObjectFactory.cs
+++ b/Assets/MirageXR/Player/Scripts/Managers/Workplace/WorkplaceObjectFactory.cs
@@ -1,4 +1,5 @@
 using i5.Toolkit.Core.ServiceCore;
+using i5.Toolkit.Core.VerboseLogging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -38,7 +39,7 @@ namespace MirageXR
                 catch (Exception e)
                 {
                     EventManager.DebugLog($"Error: Workplace manager: Couldn't create {debug}.");
-                    Debug.Log(e);
+                    AppLog.LogException(e);
                     throw;
                 }
             }
@@ -99,7 +100,7 @@ namespace MirageXR
                 {
                     Maggie.Speak("Error while trying to connect to sensor " + sensor.id);
                     EventManager.DebugLog("Error: Workplace manager: Couldn't create sensor objects.");
-                    Debug.Log(e);
+                    AppLog.LogException(e);
                     throw;
                 }
             }
@@ -225,7 +226,7 @@ namespace MirageXR
                         {
                             // If sensor poi found, link sensor display to sensor poi.
                             sensor.GetComponent<DeviceMqttBehaviour>().LinkDisplay(sensorPoi.transform);
-                            Debug.Log("Sensor poi");
+                            AppLog.LogDebug("Sensor poi");
                         }
 
                         else
@@ -233,14 +234,14 @@ namespace MirageXR
                             // If sensor poi not found, link to default poi.
                             var defaultPoi = GameObject.Find(thing.id + "/default");
                             sensor.GetComponent<DeviceMqttBehaviour>().LinkDisplay(defaultPoi.transform);
-                            Debug.Log("Default poi");
+                            AppLog.LogDebug("Default poi");
                         }
                     }
                 }
                 catch (Exception e)
                 {
                     EventManager.DebugLog("Error: Workplace manager: Couldn't create thing object: " + thing.id);
-                    Debug.Log(e);
+                    AppLog.LogException(e);
                     throw;
                 }
             }
@@ -352,7 +353,7 @@ namespace MirageXR
                 catch (Exception e)
                 {
                     EventManager.DebugLog("Error: Workplace manager: Couldn't create person objects.");
-                    Debug.Log(e);
+                    AppLog.LogException(e);
                     throw;
                 }
             }
@@ -382,7 +383,7 @@ namespace MirageXR
                 catch (Exception e)
                 {
                     EventManager.DebugLog("Error: Workplace manager: Couldn't attach user to current device.");
-                    Debug.Log(e);
+                    AppLog.LogException(e);
                     throw;
                 }
             }
@@ -398,7 +399,7 @@ namespace MirageXR
                 return;
             }
 
-            Debug.Log("Creating Detectable Object:" + detectable.id +
+            AppLog.LogInfo("Creating Detectable Object:" + detectable.id +
                 "\nPosition:" + detectable.origin_position +
                 "\nRotation:" + detectable.origin_rotation);
 
@@ -459,7 +460,7 @@ namespace MirageXR
                                       detectable.id, detectable.id, ".xml" };
                     var path = Path.Combine(paths);
 
-                    Debug.Log("VUFORIA PATH: " + path);
+                    AppLog.LogDebug("VUFORIA PATH: " + path);
 
                     // Check that we have the data set file.
                     if (!DataSet.Exists(path, VuforiaUnity.StorageType.STORAGE_ABSOLUTE))
@@ -656,7 +657,7 @@ namespace MirageXR
                 }
                 else
                 {
-                    Debug.LogError("Problem interpreting rotation value");
+                    AppLog.LogError("Problem interpreting rotation value");
                 }
             }
 
@@ -668,7 +669,7 @@ namespace MirageXR
                 }
                 else
                 {
-                    Debug.LogError("Problem interpreting poi scale value");
+                    AppLog.LogError("Problem interpreting poi scale value");
                 }
             }
 

--- a/Assets/MirageXR/Player/Scripts/Messages/ArlemMessage.cs
+++ b/Assets/MirageXR/Player/Scripts/Messages/ArlemMessage.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using UnityEngine;
 
 namespace MirageXR
 {
@@ -19,13 +20,13 @@ namespace MirageXR
         {
             if (string.IsNullOrEmpty(target))
             {
-                Debug.Log("Message target not set.");
+                AppLog.LogWarning("Message target not set.");
                 return;
             }
 
             if (string.IsNullOrEmpty(message))
             {
-                Debug.Log("Message text not set.");
+                AppLog.LogWarning("Message text not set.");
                 return;
             }
 

--- a/Assets/MirageXR/Player/Scripts/Mobile/ContentEditors/ModelEditorView.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/ContentEditors/ModelEditorView.cs
@@ -271,13 +271,13 @@ public class ModelEditorView : PopupEditorBase
         }
     }
 
-    private void LoginToSketchfab()
+    private async void LoginToSketchfab()
     {
         var service = ServiceManager.GetService<OpenIDConnectService>();
         service.OidcProvider.ClientData = _clientDataObject.clientData;
         service.LoginCompleted += OnLoginCompleted;
         service.ServerListener.ListeningUri = SketchfabManager.URL;
-        service.OpenLoginPage();
+        await service.OpenLoginPageAsync();
     }
 
     private void ShowDirectLoginPopup()

--- a/Assets/MirageXR/Player/Scripts/Mobile/ContentListItem.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/ContentListItem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using i5.Toolkit.Core.VerboseLogging;
 using MirageXR;
 using TMPro;
 using UnityEngine;
@@ -85,7 +86,7 @@ public class ContentListItem : MonoBehaviour
         var editor = _parentView.editors.FirstOrDefault(t => t.editorForType == type);
         if (editor == null)
         {
-            Debug.LogError($"there is no editor for the type {type}");
+            AppLog.LogError($"there is no editor for the type {type}");
             return;
         }
         PopupsViewer.Instance.Show(editor, _parentView.currentStep, _content);

--- a/Assets/MirageXR/Player/Scripts/Mobile/DialogWindow/DialogViewBottomInputField.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/DialogWindow/DialogViewBottomInputField.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -13,7 +14,7 @@ public class DialogViewBottomInputField : DialogViewBottom
     {
         if (model.contents.Count != 2)
         {
-            Debug.LogError("buttons content does not equal 2");
+            AppLog.LogError("buttons content does not equal 2");
             return;
         }
 

--- a/Assets/MirageXR/Player/Scripts/Mobile/DialogWindow/DialogViewMiddle.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/DialogWindow/DialogViewMiddle.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using DG.Tweening;
+using i5.Toolkit.Core.VerboseLogging;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -19,7 +20,7 @@ public class DialogViewMiddle : DialogView
 
         if (model.contents.Count != 2)
         {
-            Debug.LogError("buttons content does not equal 2");
+            AppLog.LogError("buttons content does not equal 2");
             return;
         }
 

--- a/Assets/MirageXR/Player/Scripts/Mobile/DialogWindow/DialogWindow.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/DialogWindow/DialogWindow.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -28,7 +29,7 @@ public abstract class DialogWindow : MonoBehaviour
     {
         if (Instance != null)
         {
-            Debug.LogError($"{Instance.GetType().FullName} must only be a single copy!");
+            AppLog.LogError($"{Instance.GetType().FullName} must only be a single copy!");
             return;
         }
 

--- a/Assets/MirageXR/Player/Scripts/Mobile/LoadView.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/LoadView.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -12,7 +13,7 @@ public class LoadView : MonoBehaviour
     {
         if (Instance != null)
         {
-            Debug.LogError($"{nameof(LoadView)} must only be a single copy!");
+            AppLog.LogError($"{nameof(LoadView)} must only be a single copy!");
             return;
         }
 

--- a/Assets/MirageXR/Player/Scripts/Mobile/Popup/ContentSelectorView.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/Popup/ContentSelectorView.cs
@@ -1,4 +1,5 @@
-﻿using MirageXR;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using MirageXR;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -40,7 +41,7 @@ public class ContentSelectorView : PopupBase
         var editor = _editors.FirstOrDefault(t => t.editorForType == type);
         if (editor == null)
         {
-            Debug.LogError($"there is no editor for the type {type}");
+            AppLog.LogError($"there is no editor for the type {type}");
             return;
         }
         PopupsViewer.Instance.Show(editor, _currentStep);

--- a/Assets/MirageXR/Player/Scripts/Mobile/Popup/PopupBase.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/Popup/PopupBase.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System;
 using UnityEngine;
 
@@ -14,7 +15,7 @@ public abstract class PopupBase : MonoBehaviour
         _onClose = onClose;
         if (!TryToGetArguments(args))
         {
-            Debug.LogError("error when trying to get arguments!");
+            AppLog.LogError("error when trying to get arguments!");
         }
     }
 

--- a/Assets/MirageXR/Player/Scripts/Mobile/PopupsViewer.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/PopupsViewer.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using MirageXR;
+using i5.Toolkit.Core.VerboseLogging;
 
 public class PopupsViewer : MonoBehaviour
 {
@@ -15,7 +16,7 @@ public class PopupsViewer : MonoBehaviour
     {
         if (Instance != null)
         {
-            Debug.LogError($"{Instance.GetType().FullName} must only be a single copy!");
+            AppLog.LogError($"{Instance.GetType().FullName} must only be a single copy!");
             return;
         }
 
@@ -91,7 +92,7 @@ public class PopupsViewer : MonoBehaviour
     {
         if (_stack.Count <= 0)
         {
-            Debug.LogError("Stack is empty!");
+            AppLog.LogError("Stack is empty!");
             return;
         }
 

--- a/Assets/MirageXR/Player/Scripts/Mobile/RootView.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/RootView.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using i5.Toolkit.Core.VerboseLogging;
 using MirageXR;
 using UnityEngine;
 using UnityEngine.UI;
@@ -30,7 +31,7 @@ public class RootView : BaseView
     {
         if (Instance != null)
         {
-            Debug.LogError($"{Instance.GetType().FullName} must only be a single copy!");
+            AppLog.LogError($"{Instance.GetType().FullName} must only be a single copy!");
             return;
         }
 

--- a/Assets/MirageXR/Player/Scripts/Mobile/Toast.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/Toast.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -26,7 +27,7 @@ public class Toast : MonoBehaviour
     {
         if (Instance != null)
         {
-            Debug.LogError($"{Instance.GetType().FullName} must only be a single copy!");
+            AppLog.LogError($"{Instance.GetType().FullName} must only be a single copy!");
             return;
         }
 

--- a/Assets/MirageXR/Player/Scripts/Moodle/Login.cs
+++ b/Assets/MirageXR/Player/Scripts/Moodle/Login.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System.IO;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -118,7 +119,7 @@ namespace MirageXR
             }
             else
             {
-                Debug.Log($"User login failed. Error: {response}");
+                AppLog.LogError($"User login failed. Error: {response}");
                 status.color = Color.red;
                 status.text = "Invalid login, please try again";
             }
@@ -136,7 +137,7 @@ namespace MirageXR
             DBManager.username = usernameField.text;
             welcomUserText.text = $"Welcome {DBManager.username}";
             welcomUserText.gameObject.SetActive(true);
-            Debug.Log($"{DBManager.username} logged in successfully.");
+            AppLog.LogInfo($"{DBManager.username} logged in successfully.");
             status.text = string.Empty;
             // close login menu
             ShowPanel(null);

--- a/Assets/MirageXR/Player/Scripts/Moodle/MoodleManager.cs
+++ b/Assets/MirageXR/Player/Scripts/Moodle/MoodleManager.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using ICSharpCode.SharpZipLib.Zip;
 using System.Threading.Tasks;
 using Object = UnityEngine.Object;
+using i5.Toolkit.Core.VerboseLogging;
 
 namespace MirageXR
 {
@@ -84,7 +85,7 @@ namespace MirageXR
 
             if (!DBManager.LoggedIn)
             {
-                Debug.Log("You are not logged in");
+                AppLog.LogError("You are not logged in");
                 return (false, "Error: You are not logged in");
             }
 
@@ -105,11 +106,11 @@ namespace MirageXR
             {
                 if (response.EndsWith("Saved."))
                 {
-                    Debug.Log(response);
+                    AppLog.LogDebug(response);
                 }
                 else
                 {
-                    Debug.LogError(response);
+                    AppLog.LogError(response);
                 }
 
                 Maggie.Speak("The upload is completed.");
@@ -124,12 +125,12 @@ namespace MirageXR
             // The file handling response should be displayed as Log, not LogError
             if (response.Contains("File exist"))
             {
-                Debug.Log($"Error on uploading: {response}");
+                AppLog.LogError($"Error on uploading: {response}");
             }
             else
             {
                 Maggie.Speak("Uploading ARLEM failed. Check your system administrator.");
-                Debug.LogError($"Error on uploading: {response}");
+                AppLog.LogError($"Error on uploading: {response}");
             }
 
             if (_progressText)
@@ -163,7 +164,7 @@ namespace MirageXR
             var (result, response) = await Network.GetCustomDataFromAPIRequestAsync(DBManager.token, DBManager.domain, requestValue, function, parametersValueFormat);
             if (!result)
             {
-                Debug.LogError($"Can't get UserId, error: {response}");
+                AppLog.LogError($"Can't get UserId, error: {response}");
                 return null;
             }
             DBManager.userid = Regex.Replace(response, "[^0-9]+", string.Empty); // only numbers
@@ -183,7 +184,7 @@ namespace MirageXR
             var (result, response) = await Network.GetCustomDataFromAPIRequestAsync(DBManager.token, DBManager.domain, requestValue, function, parametersValueFormat);
             if (!result)
             {
-                Debug.LogError($"Can't get Usermail, error: {response}");
+                AppLog.LogError($"Can't get Usermail, error: {response}");
                 return null;
             }
 
@@ -212,7 +213,7 @@ namespace MirageXR
                 }
             }
 
-            Debug.Log(response);
+            AppLog.LogDebug(response);
 
             return ParseArlemListJson(response);
         }
@@ -226,7 +227,7 @@ namespace MirageXR
 
             if (!result || response.StartsWith("Error"))
             {
-                Debug.LogError($"Network error\nmessage: {response}");
+                AppLog.LogError($"Network error\nmessage: {response}");
                 return null;
             }
 
@@ -244,7 +245,7 @@ namespace MirageXR
 
                 if (json == emptyJson)
                 {
-                    Debug.Log("Probably there is no public activity on the server.");
+                    AppLog.LogWarning("Probably there is no public activity on the server.");
                     return arlemList;
                 }
 
@@ -262,7 +263,7 @@ namespace MirageXR
             }
             catch (Exception e)
             {
-                Debug.LogError($"ParseArlemListJson error\nmessage: {e}");
+                AppLog.LogError($"ParseArlemListJson error\nmessage: {e}");
                 return null;
             }
         }
@@ -280,11 +281,11 @@ namespace MirageXR
             var value = result && !response.StartsWith("Error");
             if (value)
             {
-                Debug.Log(sessionID + " is deleted from server");
+                AppLog.LogInfo(sessionID + " is deleted from server");
             }
             else
             {
-                Debug.LogError(response);
+                AppLog.LogError(response);
             }
 
             return value;
@@ -302,11 +303,11 @@ namespace MirageXR
             if (!result || response.StartsWith("Error"))
             {
                 var maxLenght = 200;
-                Debug.LogError(response.Length > maxLenght ? response.Substring(0, maxLenght) : response);
+                AppLog.LogError(response.Length > maxLenght ? response.Substring(0, maxLenght) : response);
             }
             else
             {
-                Debug.Log(" Views column of the activity is increased");
+                AppLog.LogTrace(" Views column of the activity is increased");
             }
         }
 
@@ -334,7 +335,7 @@ namespace MirageXR
             }
             catch (Exception e)
             {
-                Debug.LogError($"compression error: {e}");
+                AppLog.LogError($"compression error: {e}");
             }
 
             return bytes;
@@ -377,12 +378,12 @@ namespace MirageXR
                 }
                 else
                 {
-                    Debug.LogError(error);
+                    AppLog.LogError(error);
                 }
             }
             catch (Exception e)
             {
-                Debug.LogError(e);
+                AppLog.LogException(e);
                 result = false;
             }
             finally

--- a/Assets/MirageXR/Player/Scripts/Triggers/SmartTrigger.cs
+++ b/Assets/MirageXR/Player/Scripts/Triggers/SmartTrigger.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -267,7 +268,7 @@ namespace MirageXR
             }
             catch (Exception e)
             {
-                Debug.Log(e);
+                AppLog.LogException(e);
                 return false;
             }
         }
@@ -454,7 +455,7 @@ namespace MirageXR
                 }
                 catch (Exception e)
                 {
-                    Debug.Log(e);
+                    AppLog.LogException(e);
                     throw;
                 }
             }

--- a/Assets/MirageXR/Player/Scripts/Triggers/StepTrigger.cs
+++ b/Assets/MirageXR/Player/Scripts/Triggers/StepTrigger.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System;
 using System.Globalization;
 using UnityEngine;
@@ -114,7 +115,7 @@ namespace MirageXR
                     {
                         if (!Enum.TryParse(triggerType, true, out ActionType type))
                         {
-                            Debug.Log($"can't parse {triggerType} to ActionType");
+                            AppLog.LogWarning($"can't parse {triggerType} to ActionType");
                             type = ActionType.Action;
                         }
                         activeAction.AddArlemTrigger(TriggerMode.Detect, type, MyPoi.poi, float.Parse(durationInputField.text), stepNumberInputField.text);

--- a/Assets/MirageXR/Player/Scripts/Triggers/VoiceTrigger.cs
+++ b/Assets/MirageXR/Player/Scripts/Triggers/VoiceTrigger.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System;
 using TiltBrush;
 using UnityEngine;
 
@@ -45,7 +46,7 @@ namespace MirageXR
             }
             catch (Exception e)
             {
-                Debug.Log(e);
+                AppLog.LogException(e);
                 throw;
             }
         }

--- a/Assets/MirageXR/Player/Scripts/Tutorial/ArrowHighlightingTutorialStep.cs
+++ b/Assets/MirageXR/Player/Scripts/Tutorial/ArrowHighlightingTutorialStep.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -65,7 +66,7 @@ namespace MirageXR
             }
             else
             {
-                Debug.LogError("Highlighted object missing in tutorial step: " + this.GetType().Name);
+                AppLog.LogError("Highlighted object missing in tutorial step: " + this.GetType().Name);
                 manager.CloseTutorial();
             }
         }

--- a/Assets/MirageXR/Player/Scripts/Tutorial/HololensSteps/StepLockActivityMenu.cs
+++ b/Assets/MirageXR/Player/Scripts/Tutorial/HololensSteps/StepLockActivityMenu.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -30,7 +31,7 @@ namespace MirageXR
             }
             catch
             {
-                Debug.LogError("SpriteToggle component missing in Lock for StepLockActivityMenu in Tutorial.");
+                AppLog.LogError("SpriteToggle component missing in Lock for StepLockActivityMenu in Tutorial.");
                 ExitStep();
             }
 

--- a/Assets/MirageXR/Player/Scripts/Tutorial/HololensSteps/StepUnlockActivityMenu.cs
+++ b/Assets/MirageXR/Player/Scripts/Tutorial/HololensSteps/StepUnlockActivityMenu.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using UnityEngine;
 
 namespace MirageXR
@@ -31,7 +32,7 @@ namespace MirageXR
             }
             catch
             {
-                Debug.LogError("SpriteToggle component missing in Lock for StepUnlockActivityMenu in Tutorial.");
+                AppLog.LogError("SpriteToggle component missing in Lock for StepUnlockActivityMenu in Tutorial.");
                 ExitStep();
             }
 

--- a/Assets/MirageXR/Player/Scripts/Tutorial/TutorialButton.cs
+++ b/Assets/MirageXR/Player/Scripts/Tutorial/TutorialButton.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using UnityEngine;
 using UnityEngine.UI;
 
 namespace MirageXR
@@ -24,7 +25,7 @@ namespace MirageXR
         private void Start()
         {
             int tutorialStatus = PlayerPrefs.GetInt(TutorialManager.PLAYER_PREFS_STATUS_KEY);
-            Debug.Log(tutorialStatus);
+            AppLog.LogDebug(tutorialStatus.ToString());
             if (tutorialStatus == TutorialManager.STATUS_LOAD_ON_START)
             {
                 // TODO: In the future, this should be changed to an event. Like: OnEverythingLoaded

--- a/Assets/MirageXR/Player/Scripts/UI/ClampedScrollRect.cs
+++ b/Assets/MirageXR/Player/Scripts/UI/ClampedScrollRect.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System;
 using System.Collections;
 using UnityEngine;
@@ -188,7 +189,7 @@ public class ClampedScrollRect : ScrollRect
             }
         }
 
-        Debug.LogWarningFormat("can't get child with index {0}", index);
+        AppLog.LogWarning($"can't get child with index {index}");
         return null;
     }
 
@@ -223,7 +224,7 @@ public class ClampedScrollRect : ScrollRect
         var childTransform = GetContentItem(0);
         if (!childTransform)
         {
-            Debug.LogWarning("content must have active child");
+            AppLog.LogWarning("content must have active child");
         }
 
         var spacing = _layoutGroup ? _layoutGroup.spacing : 0;
@@ -236,7 +237,7 @@ public class ClampedScrollRect : ScrollRect
         _valid = viewportSize < contentSize;
         if (!_valid && contentSize > 0 && viewportSize > 0)
         {
-            Debug.LogWarning("content must be larger then viewport");
+            AppLog.LogWarning("content must be larger then viewport");
             LayoutRebuilder.ForceRebuildLayoutImmediate((RectTransform)content.transform);
             _updateInLateUpdate = true;
         }

--- a/Assets/MirageXR/Player/Scripts/UI/SetBrandColor.cs
+++ b/Assets/MirageXR/Player/Scripts/UI/SetBrandColor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -24,7 +25,7 @@ namespace MirageXR
         {
             if (BrandManager.Instance == null)
             {
-                Debug.Log("BrandManager not initialized");
+                AppLog.LogWarning("BrandManager not initialized");
                 return;
             }
 

--- a/Assets/MirageXR/Player/Scripts/UI/TaskStationDetailMenu.cs
+++ b/Assets/MirageXR/Player/Scripts/UI/TaskStationDetailMenu.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using UnityEngine;
 using UnityEngine.UI;
 
 namespace MirageXR
@@ -84,7 +85,7 @@ namespace MirageXR
             }
             catch
             {
-                Debug.LogError("Augmentation Creation Button not found on Task Station Menu. Tutorial will not work.");
+                AppLog.LogError("Augmentation Creation Button not found on Task Station Menu. Tutorial will not work.");
             }
 
             //Setup Title and Description Field listeners. Created for tutorial.
@@ -102,7 +103,7 @@ namespace MirageXR
             }
             catch
             {
-                Debug.LogError("Action Title Input Field not found on Task Station Menu. Tutorial will not work.");
+                AppLog.LogError("Action Title Input Field not found on Task Station Menu. Tutorial will not work.");
             }
 
             SetupActionDescriptionInputField();
@@ -126,7 +127,7 @@ namespace MirageXR
             }
             catch
             {
-                Debug.LogError("Action Description Input Field not found on Task Station Menu. Tutorial will not work.");
+                AppLog.LogError("Action Description Input Field not found on Task Station Menu. Tutorial will not work.");
             }
         }
 

--- a/Assets/MirageXR/Player/Scripts/UI/TaskStep.cs
+++ b/Assets/MirageXR/Player/Scripts/UI/TaskStep.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using UnityEngine;
 using UnityEngine.UI;
 
 namespace MirageXR
@@ -135,7 +136,7 @@ namespace MirageXR
             _completedIcon.SetActive(false);
             _incompletedIcon.SetActive(true);
             _incompletedIcon.gameObject.GetComponent<Button>().enabled = false;
-            Debug.Log("RESET!");
+            AppLog.LogInfo("RESET!");
         }
 
 

--- a/Assets/MirageXR/Player/Scripts/Utilities/SmartRotationController.cs
+++ b/Assets/MirageXR/Player/Scripts/Utilities/SmartRotationController.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System;
 using UnityEngine;
 
 namespace MirageXR
@@ -99,7 +100,7 @@ namespace MirageXR
             }
             catch (Exception e)
             {
-                Debug.Log(e);
+                AppLog.LogException(e);
                 return false;
             }
         }

--- a/Assets/MirageXR/Player/Scripts/Utilities/Utilities.cs
+++ b/Assets/MirageXR/Player/Scripts/Utilities/Utilities.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System;
 using System.Globalization;
 using System.IO;
 using System.Text.RegularExpressions;
@@ -160,7 +161,7 @@ namespace MirageXR
             }
             catch (Exception e)
             {
-                Debug.Log(e);
+                AppLog.LogException(e);
                 return null;
             }
         }
@@ -275,7 +276,7 @@ namespace MirageXR
         {
             float difference = Quaternion.Angle(Quaternion.Euler(eulerOne), Quaternion.Euler(eulerTwo));
             bool sameRotation = Mathf.Abs(difference) < tolerance;
-            if (!sameRotation) { Debug.Log("Angles not the same, separated by " + difference + " degrees"); }
+            if (!sameRotation) { AppLog.LogDebug("Angles not the same, separated by " + difference + " degrees"); }
             return sameRotation;
         }
 
@@ -329,7 +330,7 @@ namespace MirageXR
             }
             catch (IOException e)
             {
-                Debug.LogError(e);
+                AppLog.LogException(e);
             }
         }
 

--- a/Assets/MirageXR/Tests/AudioRecorder/RecordTestController.cs
+++ b/Assets/MirageXR/Tests/AudioRecorder/RecordTestController.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using i5.Toolkit.Core.VerboseLogging;
 using MirageXR;
 using TMPro;
 using UnityEngine;
@@ -40,7 +41,7 @@ public class RecordTestController : MonoBehaviour
 
     private void Awake()
     {
-        Debug.Log(Microphone.devices.Length);
+        AppLog.LogDebug("Number of microphones found: " + Microphone.devices.Length);
     }
 
     private void Start()

--- a/Assets/MirageXR/Tests/Dialog/DialogTest.cs
+++ b/Assets/MirageXR/Tests/Dialog/DialogTest.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -23,8 +24,8 @@ public class DialogTest : MonoBehaviour
         _dialog.ShowMiddle(
             "Middle Dialog Test!",
             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-            "Left", () => Debug.Log("Left - click!"),
-            "Right", () => Debug.Log("Right - click!"),
+            "Left", () => AppLog.LogTrace("Left - click!"),
+            "Right", () => AppLog.LogTrace("Right - click!"),
             _toggleCanBeClosedByOutTap.isOn);
     }
 
@@ -33,9 +34,9 @@ public class DialogTest : MonoBehaviour
         _dialog.ShowMiddleMultiline(
             "Middle Multiline Dialog Test!",
             _toggleCanBeClosedByOutTap.isOn,
-            ("Item 1", () => Debug.Log("Item 1 - click!"), false),
-            ("Item 2", () => Debug.Log("Item 2 - click!"), false),
-            ("Item 3", () => Debug.Log("Item 3 - click!"), true));
+            ("Item 1", () => AppLog.LogTrace("Item 1 - click!"), false),
+            ("Item 2", () => AppLog.LogTrace("Item 2 - click!"), false),
+            ("Item 3", () => AppLog.LogTrace("Item 3 - click!"), true));
     }
 
     private void ShowBottomMultilineDialog()
@@ -43,10 +44,10 @@ public class DialogTest : MonoBehaviour
         _dialog.ShowBottomMultiline(
             "Bottom Multiline Dialog Test!",
             _toggleCanBeClosedByOutTap.isOn,
-            ("Item 1", () => Debug.Log("Item 1 - click!"), false),
-            ("Item 2", () => Debug.Log("Item 2 - click!"), false),
-            ("Item 3", () => Debug.Log("Item 3 - click!"), true),
-            ("Item 4", () => Debug.Log("Item 4 - click!"), true));
+            ("Item 1", () => AppLog.LogTrace("Item 1 - click!"), false),
+            ("Item 2", () => AppLog.LogTrace("Item 2 - click!"), false),
+            ("Item 3", () => AppLog.LogTrace("Item 3 - click!"), true),
+            ("Item 4", () => AppLog.LogTrace("Item 4 - click!"), true));
     }
 
     private void ShowBottomInputFieldDialog()
@@ -54,7 +55,7 @@ public class DialogTest : MonoBehaviour
         _dialog.ShowBottomInputField(
             "Bottom Multiline Dialog Test!",
             "Description",
-            "Left", t => Debug.Log($"Item Left - click! Text: {t}"),
-            "Right", t => Debug.Log($"Item Right - click! Text: {t}"));
+            "Left", t => AppLog.LogTrace($"Item Left - click! Text: {t}"),
+            "Right", t => AppLog.LogTrace($"Item Right - click! Text: {t}"));
     }
 }

--- a/Assets/MirageXR/Tests/NativeCameraTest/NativeCameraTest.cs
+++ b/Assets/MirageXR/Tests/NativeCameraTest/NativeCameraTest.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using System;
 using System.IO;
 using TMPro;
@@ -56,7 +57,7 @@ public class NativeCameraTest : MonoBehaviour
 
     private void OnVideoRecorded(bool result, string path)
     {
-        Debug.Log(path);
+        AppLog.LogDebug("Video record path: " + path);
         _rawImage.texture = _renderTexture;
         _pathTxt.text = path;
         _videoPlayer.url = path;

--- a/Assets/MirageXR/Tests/NewUI/ActivityListView_v2.cs
+++ b/Assets/MirageXR/Tests/NewUI/ActivityListView_v2.cs
@@ -8,6 +8,8 @@ using UnityEngine;
 using UnityEngine.UI;
 using System;
 using TMPro;
+using i5.Toolkit.Core.VerboseLogging;
+
 public class ActivityListView_v2 : BaseView
 {
     private const float HIDED_SIZE = 80f;
@@ -253,7 +255,7 @@ public class ActivityListView_v2 : BaseView
                 }
                 else
                 {
-                    Debug.Log("Cannot convert date");
+                    AppLog.LogError("Cannot convert date");
                 }
             }
         }

--- a/Assets/MirageXR/Tests/NewUI/ActivitySettings.cs
+++ b/Assets/MirageXR/Tests/NewUI/ActivitySettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using i5.Toolkit.Core.VerboseLogging;
 using MirageXR;
 using UnityEngine;
 using UnityEngine.UI;
@@ -84,7 +85,7 @@ public class ActivitySettings : PopupBase
                 "Public Upload",
                 "You have selected public upload. Once uploaded, this activity will be visable to all users.",
                 "Don't show again", () => DontShowPublicUploadWarning(),
-                "OK", () => Debug.Log("Ok!"),
+                "OK", () => AppLog.LogTrace("Ok!"),
                 true);
         }
 

--- a/Assets/MirageXR/Tests/NewUI/ContentListItem_v2.cs
+++ b/Assets/MirageXR/Tests/NewUI/ContentListItem_v2.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using i5.Toolkit.Core.VerboseLogging;
 using MirageXR;
 using TMPro;
 using UnityEngine;
@@ -75,7 +76,7 @@ public class ContentListItem_v2 : MonoBehaviour
         var editor = _parentView.editors.FirstOrDefault(t => t.editorForType == type);
         if (editor == null)
         {
-            Debug.LogError($"there is no editor for the type {type}");
+            AppLog.LogError($"there is no editor for the type {type}");
             return;
         }
 

--- a/Assets/MirageXR/Tests/NewUI/ContentSelectorView_v2.cs
+++ b/Assets/MirageXR/Tests/NewUI/ContentSelectorView_v2.cs
@@ -1,3 +1,4 @@
+using i5.Toolkit.Core.VerboseLogging;
 using MirageXR;
 using System;
 using System.Collections.Generic;
@@ -40,7 +41,7 @@ public class ContentSelectorView_v2 : PopupBase
         var editor = _editors.FirstOrDefault(t => t.editorForType == type);
         if (editor == null)
         {
-            Debug.LogError($"there is no editor for the type {type}");
+            AppLog.LogError($"there is no editor for the type {type}");
             return;
         }
         PopupsViewer.Instance.Show(editor, _currentStep);

--- a/Assets/MirageXR/Tests/NewUI/OnboardingTutorialView.cs
+++ b/Assets/MirageXR/Tests/NewUI/OnboardingTutorialView.cs
@@ -1,5 +1,6 @@
 using System;
 using DG.Tweening;
+using i5.Toolkit.Core.VerboseLogging;
 using MirageXR;
 using UnityEngine;
 using UnityEngine.UI;
@@ -102,7 +103,7 @@ public class OnboardingTutorialView : PopupBase
                 _btnSkipTutorials.gameObject.SetActive(true);
                 break;
             default:
-                Debug.LogError("Page View: Out of range");
+                AppLog.LogError("Page View: Out of range");
                 break;
         }
 

--- a/Assets/MirageXR/Tests/NewUI/RootView_v2.cs
+++ b/Assets/MirageXR/Tests/NewUI/RootView_v2.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using i5.Toolkit.Core.VerboseLogging;
 using MirageXR;
 using UnityEngine;
 
@@ -55,7 +56,7 @@ public class RootView_v2 : BaseView
     {
         if (Instance != null)
         {
-            Debug.LogError($"{Instance.GetType().FullName} must only be a single copy!");
+            AppLog.LogError($"{Instance.GetType().FullName} must only be a single copy!");
             return;
         }
 

--- a/Assets/MirageXR/Tests/NewUI/Tutorial.cs
+++ b/Assets/MirageXR/Tests/NewUI/Tutorial.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using i5.Toolkit.Core.VerboseLogging;
 using MirageXR;
 using UnityEngine;
 
@@ -111,7 +112,7 @@ public class Tutorial : MonoBehaviour
             }
             else
             {
-                Debug.LogError($"Can't find TutorialModel with id = '{model.id}'");
+                AppLog.LogError($"Can't find TutorialModel with id = '{model.id}'");
                 model.id = null;
             }
         }

--- a/Assets/MirageXR/Tests/NewUI/ViewCamera.cs
+++ b/Assets/MirageXR/Tests/NewUI/ViewCamera.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using i5.Toolkit.Core.VerboseLogging;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace MirageXR
@@ -37,7 +38,7 @@ namespace MirageXR
                     break;
                 case DeviceFormat.Unknown:
                 default:
-                    Debug.Log("Unknown format");
+                    AppLog.LogWarning("Unknown format");
                     break;
             }
         }

--- a/Assets/Resources/VuforiaConfiguration.asset
+++ b/Assets/Resources/VuforiaConfiguration.asset
@@ -24,7 +24,7 @@ MonoBehaviour:
     modelTargetRecoWhileExtendedTracked: 1
     shareRecordingsInITunes: 0
     version: 9.8.5
-    eulaAcceptedVersions: '{"Values":["0.0","8.3","8.1","7.2","7.5","8.0","8.6","8.5","9.3","9.4","9.6","9.7","9.5","9.8","10.6","10.11"]}'
+    eulaAcceptedVersions: '{"Values":["0.0","8.3","8.1","7.2","7.5","8.0","8.6","8.5","9.3","9.4","9.6","9.7","9.5","9.8","10.6","10.11","10.10"]}'
   database:
     disableModelExtraction: 0
   shaders:

--- a/Assets/UnitTests/EditorTests/PlayerUtilitiesTests.cs
+++ b/Assets/UnitTests/EditorTests/PlayerUtilitiesTests.cs
@@ -4,9 +4,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEditor.SceneManagement;
 using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Tests
 {
@@ -186,6 +188,9 @@ namespace Tests
         public void CreateObject_ParentNameDoesNotExist_ReturnsNull()
         {
             const string id = "My ID";
+
+            LogAssert.Expect(LogType.Error, new Regex(@".*Object.*not found"));
+
             GameObject res = Utilities.CreateObject(id, "this parent does not exist");
 
             Assert.IsTrue(res == null);

--- a/Assets/UnitTests/PlayModeTests/CalibrationTests.cs
+++ b/Assets/UnitTests/PlayModeTests/CalibrationTests.cs
@@ -1,4 +1,5 @@
 ﻿using i5.Toolkit.Core.ServiceCore;
+using i5.Toolkit.Core.VerboseLogging;
 using MirageXR;
 using NUnit.Framework;
 using System.Collections;
@@ -225,7 +226,7 @@ namespace Tests
             string targetPath = Path.Combine(Application.persistentDataPath, "calibrationTest");
 
             if (!Directory.Exists(sourcePath)) {
-                Debug.LogError("Calibration testing files not found");
+                AppLog.LogError("Calibration testing files not found");
                 return;
             }
 
@@ -681,7 +682,7 @@ namespace Tests
             // make sure test is runnable
             yield return EnsureTestReadiness();
 
-            Debug.Log("press space bar to end testing");
+            AppLog.LogInfo("press space bar to end testing");
 
             // pause for shutdown or debugging
             yield return new WaitUntil(() => Input.GetKeyDown(KeyCode.Space));

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -24,7 +24,7 @@
     }
   ],
   "dependencies": {
-    "com.i5.toolkit.core": "1.8.1",
+    "com.i5.toolkit.core": "1.9.0",
     "com.microsoft.mixedreality.toolkit.examples": "2.8.2",
     "com.microsoft.mixedreality.toolkit.foundation": "2.8.2",
     "com.microsoft.mixedreality.toolkit.tools": "2.8.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.i5.toolkit.core": {
-      "version": "1.8.1",
+      "version": "1.9.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
This pull request closes #1050.

It introduces a new logging system where we can filter at runtime how detailed the produced logs should be. It provides the following levels:

1. Critical Error: something went very wrong and it is unclear whether the application can continue running
2. Error: something went wrong
3. Warning: an unexpected state was found and it might lead to an error later
4. Info: informs the user about major events happening; this should be the standard level for reporting logs
5. Debug: gives additional information such as values of variables, etc. so that developers can gain more insights about how the application is operating
6. Trace: very detailed log statements which trace exact code execution paths and reasoning on why that execution path is happening

To use the verbose logging system, instead of writing `Debug.Log`, developers should now use `AppLog.Log...`. It provides different methods such as `LogInfo`, `LogDebug` and `LogTrace` to specify the level of the log statement.

`Debug.Log` still works but bypasses the system and so these statements are always logged independent on the set filtering level.

Currently, the project is set up to generate all log statements in the editor and to filter out debug and trace statements outside of the editor. This is configured in the MirageXR bootstrapper script. We should at some point add an option in the UI so that the user can switch to a debugging mode where the more detailed statements are also generated.