### PR TITLE
The calibration marker orientation should not affect the rotation of augmentations when they spawn

### DIFF
--- a/Assets/MirageXR/Common/Scripts/Managers/CalibrationManager.cs
+++ b/Assets/MirageXR/Common/Scripts/Managers/CalibrationManager.cs
@@ -161,7 +161,7 @@ public class CalibrationManager : MonoBehaviour
     private void UpdateAnchorPosition()
     {
         _anchor.transform.position = _calibrationTool.transform.position;
-        _anchor.transform.rotation = _calibrationTool.transform.rotation;
+        //_anchor.transform.rotation = _calibrationTool.transform.rotation;
     }
 
     private static Transform CreateAnchor()


### PR DESCRIPTION
Calibration has been optimized
The calibration marker orientation should not affect the rotation of augmentations when they spawn

https://github.com/WEKIT-ECS/MIRAGE-XR/issues/1295