### PR TITLE
CI Pipeline switch to scheduled builds

### DIFF
--- a/.github/workflows/linux_workflow.yml
+++ b/.github/workflows/linux_workflow.yml
@@ -1,5 +1,7 @@
-name: Linux workflow
-on: [push, pull_request]
+name: Linux Workflow (Unit tests and Android build)
+on:
+  schedule:
+    - cron: 0 19 * * 5
 jobs:
   test:
     name: Test Unity

--- a/.github/workflows/windows_workflow.yml
+++ b/.github/workflows/windows_workflow.yml
@@ -1,15 +1,7 @@
-name: Windows workflow
+name: Windows Workflow (HoloLens Builds)
 on: 
-  push:
-    branches:
-    - master
-    - develop
-  pull_request:
-    types:
-      - opened
-    branches:
-    - master
-    - develop
+  schedule:
+    - cron: 0 19 * * 5
   release:
     types: [published]
 jobs:


### PR DESCRIPTION
This pull request switches from CI pipelines that run on push actions to scheduled builds that happen every Friday at 19:00 UTC. This change is made in order to reduce the space consumption on the runners and to keep better track of the individual pipeline runs.

With the current setup, the builds will only happen for the master branch. I will integrate a similar schedule for the develop branch in a separate pull request.