### PR TITLE
1689 fixes MoodleManager hit counter error

### DIFF
--- a/Assets/MirageXR/Player/Scripts/ActivitySelection/SessionButton.cs
+++ b/Assets/MirageXR/Player/Scripts/ActivitySelection/SessionButton.cs
@@ -90,7 +90,7 @@ namespace MirageXR
             PlayerPrefs.Save();
 
             // update the view of the activity on Moodle server after loading
-            await RootObject.Instance.moodleManager.UpdateViewsOfActivity(_selectedListViewItem.Content.ItemID);
+            await RootObject.Instance.moodleManager.UpdateViewsOfActivity(_selectedListViewItem.Content.ItemID, _selectedListViewItem.Content.ExistsRemotely);
 
             //StartCoroutine(SwitchToPlayerScene(activityJsonFileName));
             await RootObject.Instance.editorSceneService.LoadEditorAsync();

--- a/Assets/MirageXR/Player/Scripts/Mobile/ActivityListItem.cs
+++ b/Assets/MirageXR/Player/Scripts/Mobile/ActivityListItem.cs
@@ -126,7 +126,7 @@ namespace MirageXR
             LoadView.Instance.Show();
             var activityJsonFileName = LocalFiles.GetActivityJsonFilename(_container.FileIdentifier);
             await RootObject.Instance.editorSceneService.LoadEditorAsync();
-            await RootObject.Instance.moodleManager.UpdateViewsOfActivity(_container.ItemID);
+            await RootObject.Instance.moodleManager.UpdateViewsOfActivity(_container.ItemID, _container.ExistsRemotely);
             await RootObject.Instance.activityManager.LoadActivity(activityJsonFileName);
             LoadView.Instance.Hide();
         }

--- a/Assets/MirageXR/Scripts/UI/NewUI/ActivityListItem_v2.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/ActivityListItem_v2.cs
@@ -149,7 +149,7 @@ namespace MirageXR
             LoadView.Instance.Show();
             var activityJsonFileName = LocalFiles.GetActivityJsonFilename(_container.FileIdentifier);
             await RootObject.Instance.editorSceneService.LoadEditorAsync();
-            await RootObject.Instance.moodleManager.UpdateViewsOfActivity(_container.ItemID);
+            await RootObject.Instance.moodleManager.UpdateViewsOfActivity(_container.ItemID, _container.ExistsRemotely);
             await RootObject.Instance.activityManager.LoadActivity(activityJsonFileName);
             LoadView.Instance.Hide();
         }

--- a/Assets/MirageXR/Services/Moodle/MoodleManager.cs
+++ b/Assets/MirageXR/Services/Moodle/MoodleManager.cs
@@ -215,7 +215,6 @@ namespace MirageXR
 
             //Comented out the below debug log due to the size of the message
             //Debug.LogDebug(response);
-
             return ParseArlemListJson(response);
         }
 
@@ -296,24 +295,37 @@ namespace MirageXR
         /// Increase the views of the activity on server by 1
         /// </summary>
         /// <param name="itemID">The id of the item for which the activity views should be increased</param>
-        public async Task UpdateViewsOfActivity(string itemID)
+        /// <param name="existsRemotely">Boolean indicating whether the item was already uploaded and exists on the server at all</param>
+        public async Task UpdateViewsOfActivity(string itemID, bool existsRemotely = false)
         {
-            var (result, response) = await Network.GetCustomDataFromDBRequestAsync(DBManager.userid, DBManager.domain, "updateViews", DBManager.token, itemID);
-
-            // Return null if some error happened
-            if (!result || response.StartsWith("Error"))
+            if (existsRemotely)
             {
-                var maxLenght = 200;
-                var responseLength = response.Length > maxLenght ? response.Substring(0, maxLenght) : response;
-                Debug.LogError("[MoodleManager] error while increasing the hit counter of the activity:" + responseLength);
+                var (result, response) = await Network.GetCustomDataFromDBRequestAsync(DBManager.userid, DBManager.domain, "updateViews", DBManager.token, itemID);
+
+                // Return null if some error happened
+                if (!result || response.StartsWith("Error"))
+                {
+                    var maxLenght = 200;
+                    var responseLength = response.Length > maxLenght ? response.Substring(0, maxLenght) : response;
+                    AppLog.LogError("[MoodleManager] error while increasing the hit counter of the activity:" + responseLength);
+                }
+                else
+                {
+                    AppLog.LogInfo("[MoodleManager] hit counter of activity successfully increased");
+                }
             }
             else
             {
-                Debug.LogTrace("[MoodleManager] hit counter of activity successfully increased");
+                AppLog.LogInfo("[MoodleManager] this is a local activity, so I have NOT updated the online hit counter");
             }
         }
 
-        // Zips the workshop files
+        /// <summary>
+        /// Zips ARLEM files into archive
+        /// </summary>
+        /// <param name="path">Target location</param>
+        /// <param name="recordingId">Session ID (part of the filename), appending -activity.json/-workplace.json</param>
+        /// <returns>Returns the compressed file as byte code</returns>
         private static async Task<byte[]> CompressRecord(string path, string recordingId)
         {
             byte[] bytes = null;

--- a/Assets/MirageXR/Services/Moodle/MoodleManager.cs
+++ b/Assets/MirageXR/Services/Moodle/MoodleManager.cs
@@ -274,8 +274,7 @@ namespace MirageXR
                 RootView_v2.Instance.dialog.ShowMiddle(
                     "Network Error",
                     "Could not connect to server, showing local activities only.",
-                    "OK", () => AppLog.LogInfo("[MoodleManager] User acknowledged network error"),
-                    "Cancel", () => AppLog.LogInfo("[MoodleManager] User acknowledged network error"),
+                    "OK", () => AppLog.LogInfo("[MoodleManager] User acknowledged network error")
                     true);
                 Debug.LogWarning($"[MoodleManager] ParseArlemListJson error\nmessage: {e}");
                 return null;

--- a/Assets/MirageXR/Services/Moodle/MoodleManager.cs
+++ b/Assets/MirageXR/Services/Moodle/MoodleManager.cs
@@ -222,15 +222,23 @@ namespace MirageXR
         private static async Task<string> GetArlemListJson(string serverUrl)
         {
             const string responseValue = "arlemlist";
+            bool result = false;
+            string response = null;
 
-            var (result, response) = await Network.GetCustomDataFromDBRequestAsync(DBManager.userid, serverUrl, responseValue, DBManager.token);
+            try
+            {
+                (result, response) = await Network.GetCustomDataFromDBRequestAsync(DBManager.userid, serverUrl, responseValue, DBManager.token);
+            }
+            catch (System.Net.WebException ex)
+            {
+                AppLog.LogError($"[MoodleManager] More significant network error caught in GetArlemListJson(): {ex.Response}");
+            }
 
             if (!result || response.StartsWith("Error"))
             {
-                Debug.LogError($"[MoodleManager] Network error: {response}");
+                AppLog.LogWarning($"[MoodleManager] Network error: {response}");
                 return null;
             }
-
             return response;
         }
 
@@ -263,7 +271,13 @@ namespace MirageXR
             }
             catch (Exception e)
             {
-                Debug.LogError($"[MoodleManager] ParseArlemListJson error\nmessage: {e}");
+                RootView_v2.Instance.dialog.ShowMiddle(
+                    "Network Error",
+                    "Could not connect to server, showing local activities only.",
+                    "OK", () => AppLog.LogInfo("[MoodleManager] User acknowledged network error"),
+                    "Cancel", () => AppLog.LogInfo("[MoodleManager] User acknowledged network error"),
+                    true);
+                Debug.LogWarning($"[MoodleManager] ParseArlemListJson error\nmessage: {e}");
                 return null;
             }
         }


### PR DESCRIPTION
MoodleManager tried to increase the hit counter also for local activities, throwing an error. 

Fixes #1689 by adding a boolean flag to the UpdateViewsOfActivity method to indicate whether the activity existsRemotely.