### PR TITLE
1725 added try/catch statement around xAPI service change routine

### DIFF
--- a/Assets/MirageXR/Services/ExperienceAPI/ExperienceService.cs
+++ b/Assets/MirageXR/Services/ExperienceAPI/ExperienceService.cs
@@ -4,6 +4,8 @@ using MirageXR;
 using i5.Toolkit.Core.ServiceCore;
 using i5.Toolkit.Core.ExperienceAPI;
 using Newtonsoft.Json.Linq;
+using i5.Toolkit.Core.Utilities;
+using i5.Toolkit.Core.VerboseLogging;
 
 namespace MirageXR
 {
@@ -317,7 +319,11 @@ namespace MirageXR
                         context.AddParentActivity(parentActivityIRI);
                         statement.context = context;
 
-                        await xAPIClient.SendStatementAsync(statement);
+                        WebResponse<string> resp = await xAPIClient.SendStatementAsync(statement);
+                        if (resp.Code >= 400)
+                        {
+                            AppLog.LogError("[ExperienceService] xAPI endpoint reports error in response to the statement sent: " + resp.ErrorMessage + ", xAPI endpoint: " + xAPIClient.XApiEndpoint);
+                        }
                     }
                 }
                 else
@@ -339,7 +345,12 @@ namespace MirageXR
             result.AddMeasurementAttempt(measurementIRI, measurementValue);
             statement.result = result;
 
-            await xAPIClient.SendStatementAsync(statement);
+            //await xAPIClient.SendStatementAsync(statement);
+            WebResponse<string> resp = await xAPIClient.SendStatementAsync(statement);
+            if (resp.Code >= 400)
+            {
+                AppLog.LogError("[ExperienceService] xAPI endpoint reports error in response to the statement sent: " + resp.ErrorMessage + ", xAPI endpoint: " + xAPIClient.XApiEndpoint);
+            }
         }
 
         // called if an activity is completed
@@ -352,7 +363,12 @@ namespace MirageXR
             obj.AddName(activityManager.Activity.name);
             Statement statement = GenerateStatement(verb, obj);
 
-            await xAPIClient.SendStatementAsync(statement);
+            //await xAPIClient.SendStatementAsync(statement);
+            WebResponse<string> resp = await xAPIClient.SendStatementAsync(statement);
+            if (resp.Code >= 400)
+            {
+                AppLog.LogError("[ExperienceService] xAPI endpoint reports error in response to the statement sent: " + resp.ErrorMessage + ", xAPI endpoint: " + xAPIClient.XApiEndpoint);
+            }
         }
 
         // called if an activity is loaded
@@ -364,7 +380,12 @@ namespace MirageXR
             obj.AddName(activityManager.Activity.name);
             Statement statement = GenerateStatement(verb, obj);
 
-            await xAPIClient.SendStatementAsync(statement);
+            //await xAPIClient.SendStatementAsync(statement);
+            WebResponse<string> resp = await xAPIClient.SendStatementAsync(statement);
+            if (resp.Code >= 400)
+            {
+                AppLog.LogError("[ExperienceService] xAPI endpoint reports error in response to the statement sent: " + resp.ErrorMessage + ", xAPI endpoint: " + xAPIClient.XApiEndpoint);
+            }
         }
 
         // called if an action step is activated
@@ -389,7 +410,12 @@ namespace MirageXR
             context.AddParentActivity(parentActivityIRI);
             statement.context = context;
 
-            await xAPIClient.SendStatementAsync(statement);
+            //await xAPIClient.SendStatementAsync(statement);
+            WebResponse<string> resp = await xAPIClient.SendStatementAsync(statement);
+            if (resp.Code >= 400)
+            {
+                AppLog.LogError("[ExperienceService] xAPI endpoint reports error in response to the statement sent: " + resp.ErrorMessage + ", xAPI endpoint: " + xAPIClient.XApiEndpoint);
+            }
         }
 
         // called if an action step is deactivated
@@ -414,7 +440,12 @@ namespace MirageXR
             context.AddParentActivity(parentActivityIRI);
             statement.context = context;
 
-            await xAPIClient.SendStatementAsync(statement);
+            //await xAPIClient.SendStatementAsync(statement);
+            WebResponse<string> resp = await xAPIClient.SendStatementAsync(statement);
+            if (resp.Code >= 400)
+            {
+                AppLog.LogError("[ExperienceService] xAPI endpoint reports error in response to the statement sent: " + resp.ErrorMessage + ", xAPI endpoint: " + xAPIClient.XApiEndpoint);
+            }
         }
 
 

--- a/Assets/MirageXR/Services/MirageXRServiceBootstrapper.cs
+++ b/Assets/MirageXR/Services/MirageXRServiceBootstrapper.cs
@@ -47,11 +47,12 @@ namespace MirageXR
 
             if (xAPICredentialsWEKIT != null)
             {
+                AppLog.LogTrace("[MirageXRServiceBootstrapper] registering xAPI service");
                 ServiceManager.RegisterService(new ExperienceService(CreateXAPIClient("WEKIT")));
             }
             else
             {
-                Debug.LogWarning("xAPI credentials not set. You will not be able to use the ExperienceService and xAPI analytics");
+                AppLog.LogWarning("xAPI credentials not set. You will not be able to use the ExperienceService and xAPI analytics");
             }
 
             ServiceManager.RegisterService(new VideoAudioTrackGlobalService());
@@ -62,7 +63,7 @@ namespace MirageXR
             };
 
 #if !UNITY_EDITOR
-            oidc.RedirectURI = "https://wekit-community.org/sketchfab/callback.php";
+            oidc.RedirectURI = "https://wekit-ecs.com/sso/callback.php";
 #else
             // here could be the link to a nicer web page that tells the user to return to the app
 #endif
@@ -93,14 +94,6 @@ namespace MirageXR
                     {
                         XApiEndpoint = new System.Uri("https://lrs.wekit-ecs.com/data/xAPI"),
                         AuthorizationToken = xAPICredentialsWEKIT.authToken,
-                        Version = "1.0.3",
-                    };
-                    break;
-                case "ARETE":
-                    xAPIClient = new ExperienceAPIClient
-                    {
-                        XApiEndpoint = new System.Uri("https://learninglocker.vicomtech.org/data/xAPI"),
-                        AuthorizationToken = xAPICredentialsARETE.authToken,
                         Version = "1.0.3",
                     };
                     break;

--- a/Assets/MirageXR/Services/MirageXRServiceBootstrapper.cs
+++ b/Assets/MirageXR/Services/MirageXRServiceBootstrapper.cs
@@ -1,4 +1,5 @@
-﻿using i5.Toolkit.Core.DeepLinkAPI;
+﻿using System;
+using i5.Toolkit.Core.DeepLinkAPI;
 using i5.Toolkit.Core.ExperienceAPI;
 using i5.Toolkit.Core.OpenIDConnectClient;
 using i5.Toolkit.Core.ServiceCore;
@@ -81,8 +82,8 @@ namespace MirageXR
             ServiceManager.RemoveService<DeepLinkingService>();
         }
 
-        private ExperienceAPIClient CreateXAPIClient(string client) {
-
+        private ExperienceAPIClient CreateXAPIClient(string client)
+        {
             ExperienceAPIClient xAPIClient = null;
 
             switch (client)
@@ -111,7 +112,14 @@ namespace MirageXR
 
         private void ChangeXAPI(DBManager.LearningRecordStores selectedLRS)
         {
-            ServiceManager.RemoveService<ExperienceService>();
+            try
+            {
+                ServiceManager.RemoveService<ExperienceService>();
+            }
+            catch (Exception ex)
+            {
+                AppLog.LogError($"[MirageXRServiceBootstrapper] Tried to unregister xAPI service via i5 ServiceManager, but failed to unregister: {ex.Message}");
+            }
 
             switch (selectedLRS)
             {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "com.atteneder.gltfast": "6.0.1",
-    "com.i5.toolkit.core": "1.9.0",
+    "com.i5.toolkit.core": "1.9.1",
     "com.microsoft.mixedreality.openxr": "file:MixedReality/com.microsoft.mixedreality.openxr-1.7.0.tgz",
     "com.microsoft.mixedreality.toolkit.examples": "2.8.2",
     "com.microsoft.mixedreality.toolkit.foundation": "2.8.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -13,7 +13,7 @@
       "url": "https://package.openupm.com"
     },
     "com.i5.toolkit.core": {
-      "version": "1.9.0",
+      "version": "1.9.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Even though I could not reproduce the error in editor, I noticed that there was no try catch statement around removing the 'old' service when switching. From the i5 error message this seems to be the culprit. This may not resolve the problem in full, but would make sense if an error is thrown: the code tried to first remove in ```onEnable```, before then creating a new service. This removal is now wrapped into a try-catch statement, so if this was the issue, it should now be resolved. Surprising is only that this issue could not be reproduced in editor - might be that i5 prevents xAPI error handling if run within editor? @BenediktHensen is that the case?

(hopefully) fixes #1725 