### PR TITLE
Fixed the xAPI connection

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {
     "com.atteneder.gltfast": "6.0.1",
-    "com.i5.toolkit.core": "1.9.1",
+    "com.i5.toolkit.core": "1.9.2",
     "com.microsoft.mixedreality.openxr": "file:MixedReality/com.microsoft.mixedreality.openxr-1.7.0.tgz",
     "com.microsoft.mixedreality.toolkit.examples": "2.8.2",
     "com.microsoft.mixedreality.toolkit.foundation": "2.8.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -13,7 +13,7 @@
       "url": "https://package.openupm.com"
     },
     "com.i5.toolkit.core": {
-      "version": "1.9.1",
+      "version": "1.9.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
This pull request fixes #1736. It ensures that a compatible Unity package version of Newtonsoft is installed and bumps the i5 Toolkit to a version which supports Unity's Newtonsoft package.

With these changes, the xAPI client is generating statements again.