### PR TITLE
Supressed xAPI calls when running in the editor

### DIFF
--- a/Assets/MirageXR/Scripts/Logger/XApiMockWebConnector.cs
+++ b/Assets/MirageXR/Scripts/Logger/XApiMockWebConnector.cs
@@ -1,0 +1,60 @@
+using i5.Toolkit.Core.ExperienceAPI;
+using i5.Toolkit.Core.Utilities;
+using i5.Toolkit.Core.VerboseLogging;
+using Newtonsoft.Json;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace MirageXR
+{
+	public class XApiMockWebConnector : IRestConnector
+	{
+		public Task<WebResponse<string>> DeleteAsync(string uri, Dictionary<string, string> headers = null)
+		{
+			AppLog.LogDebug($"Delete request sent to {uri} (mocked because sent from editor)");
+			return Task.FromResult(CreateFakeWebResponse());
+		}
+
+		public Task<WebResponse<string>> GetAsync(string uri, Dictionary<string, string> headers = null)
+		{
+			AppLog.LogDebug($"Get request sent to {uri} (mocked because sent from editor)");
+			return Task.FromResult(CreateFakeWebResponse());
+		}
+
+		public Task<WebResponse<string>> PostAsync(string uri, string postJson, Dictionary<string, string> headers = null)
+		{
+			AppLog.LogDebug($"Post statement sent to {uri} (mocked because sent from editor)\nJSON:\n{postJson}");
+			return Task.FromResult(CreateFakeWebResponse());
+		}
+
+		public Task<WebResponse<string>> PostAsync(string uri, byte[] postData, Dictionary<string, string> headers = null)
+		{
+			string json = Encoding.UTF8.GetString(postData);
+			AppLog.LogDebug($"xAPI statement for {uri} (mocked because sent from editor)\nStatement JSON:\n{json}", this);
+
+			return Task.FromResult(CreateFakeWebResponse());
+		}
+
+		public Task<WebResponse<string>> PutAsync(string uri, string putJson, Dictionary<string, string> headers = null)
+		{
+			AppLog.LogDebug($"Put request sent to {uri} (mocked because sent from editor)\nJSON:\n{putJson}");
+			return Task.FromResult(CreateFakeWebResponse());
+		}
+
+		public Task<WebResponse<string>> PutAsync(string uri, byte[] putData, Dictionary<string, string> headers = null)
+		{
+			string json = Encoding.UTF8.GetString(putData);
+			AppLog.LogDebug($"Put request sent to {uri} (mocked because sent from editor)\nJSON:\n{json}");
+			return Task.FromResult(CreateFakeWebResponse());
+		}
+
+		private WebResponse<string> CreateFakeWebResponse()
+		{
+			WebResponse<string> res = new WebResponse<string>("mock call success", null, 200);
+			return res;
+		}
+	}
+}

--- a/Assets/MirageXR/Scripts/Logger/XApiMockWebConnector.cs.meta
+++ b/Assets/MirageXR/Scripts/Logger/XApiMockWebConnector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5112ec4e01464f04583c07cfceeaa691
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MirageXR/Services/MirageXRServiceBootstrapper.cs
+++ b/Assets/MirageXR/Services/MirageXRServiceBootstrapper.cs
@@ -8,118 +8,123 @@ using UnityEngine;
 
 namespace MirageXR
 {
-    public class MirageXRServiceBootstrapper : BaseServiceBootstrapper
-    {
-        [SerializeField]
-        private VestServiceConfiguration vestServiceConfiguration;
-        [SerializeField]
-        private ExperienceAPIClientCredentials xAPICredentialsWEKIT;
-        [SerializeField]
-        private ExperienceAPIClientCredentials xAPICredentialsARETE;
+	public class MirageXRServiceBootstrapper : BaseServiceBootstrapper
+	{
+		[SerializeField]
+		private VestServiceConfiguration vestServiceConfiguration;
+		[SerializeField]
+		private ExperienceAPIClientCredentials xAPICredentialsWEKIT;
+		[SerializeField]
+		private ExperienceAPIClientCredentials xAPICredentialsARETE;
 
-        [SerializeField] private DeepLinkDefinition deepLinkAPI;
+		[SerializeField] private DeepLinkDefinition deepLinkAPI;
 
-        private void OnEnable()
-        {
-            EventManager.XAPIChanged += ChangeXAPI;
-        }
+		private void OnEnable()
+		{
+			EventManager.XAPIChanged += ChangeXAPI;
+		}
 
-        private void OnDisable()
-        {
-            EventManager.XAPIChanged -= ChangeXAPI;
-        }
+		private void OnDisable()
+		{
+			EventManager.XAPIChanged -= ChangeXAPI;
+		}
 
-        protected override void RegisterServices()
-        {
+		protected override void RegisterServices()
+		{
 #if UNITY_EDITOR
-            Debug.MinimumLogLevel = LogLevel.TRACE;
+			Debug.MinimumLogLevel = LogLevel.TRACE;
 #else
             Debug.MinimumLogLevel = LogLevel.INFO;
 #endif
 
-            ServiceManager.RegisterService(new WorldAnchorService());
-            ServiceManager.RegisterService(new KeywordService());
+			ServiceManager.RegisterService(new WorldAnchorService());
+			ServiceManager.RegisterService(new KeywordService());
 
-            ServiceManager.RegisterService(new VestService
-            {
-                VestEnabled = vestServiceConfiguration.vestEnabled
-            });
+			ServiceManager.RegisterService(new VestService
+			{
+				VestEnabled = vestServiceConfiguration.vestEnabled
+			});
 
-            if (xAPICredentialsWEKIT != null)
-            {
-                AppLog.LogTrace("[MirageXRServiceBootstrapper] registering xAPI service");
-                ServiceManager.RegisterService(new ExperienceService(CreateXAPIClient("WEKIT")));
-            }
-            else
-            {
-                AppLog.LogWarning("xAPI credentials not set. You will not be able to use the ExperienceService and xAPI analytics");
-            }
+			if (xAPICredentialsWEKIT != null)
+			{
+				AppLog.LogTrace("[MirageXRServiceBootstrapper] registering xAPI service");
+				ServiceManager.RegisterService(new ExperienceService(CreateXAPIClient("WEKIT")));
+			}
+			else
+			{
+				AppLog.LogWarning("xAPI credentials not set. You will not be able to use the ExperienceService and xAPI analytics");
+			}
 
-            ServiceManager.RegisterService(new VideoAudioTrackGlobalService());
+			ServiceManager.RegisterService(new VideoAudioTrackGlobalService());
 
-            OpenIDConnectService oidc = new OpenIDConnectService
-            {
-                OidcProvider = new SketchfabOidcProvider()
-            };
+			OpenIDConnectService oidc = new OpenIDConnectService
+			{
+				OidcProvider = new SketchfabOidcProvider()
+			};
 
 #if !UNITY_EDITOR
             oidc.RedirectURI = "https://wekit-ecs.com/sso/callback.php";
 #else
-            // here could be the link to a nicer web page that tells the user to return to the app
+			// here could be the link to a nicer web page that tells the user to return to the app
 #endif
 
-            ServiceManager.RegisterService(oidc);
+			ServiceManager.RegisterService(oidc);
 
-            DeepLinkingService deepLinks = new DeepLinkingService();
-            ServiceManager.RegisterService(deepLinks);
+			DeepLinkingService deepLinks = new DeepLinkingService();
+			ServiceManager.RegisterService(deepLinks);
 
-            deepLinkAPI = new DeepLinkDefinition();
-            deepLinks.AddDeepLinkListener(deepLinkAPI);
-        }
+			deepLinkAPI = new DeepLinkDefinition();
+			deepLinks.AddDeepLinkListener(deepLinkAPI);
+		}
 
-        protected override void UnRegisterServices()
-        {
-            ServiceManager.GetService<DeepLinkingService>().RemoveDeepLinkListener(deepLinkAPI);
-            ServiceManager.RemoveService<DeepLinkingService>();
-        }
+		protected override void UnRegisterServices()
+		{
+			ServiceManager.GetService<DeepLinkingService>().RemoveDeepLinkListener(deepLinkAPI);
+			ServiceManager.RemoveService<DeepLinkingService>();
+		}
 
-        private ExperienceAPIClient CreateXAPIClient(string client)
-        {
-            ExperienceAPIClient xAPIClient = null;
+		private ExperienceAPIClient CreateXAPIClient(string client)
+		{
+			ExperienceAPIClient xAPIClient = null;
 
-            switch (client)
-            {
-                case "WEKIT":
-                    xAPIClient = new ExperienceAPIClient
-                    {
-                        XApiEndpoint = new System.Uri("https://lrs.wekit-ecs.com/data/xAPI"),
-                        AuthorizationToken = xAPICredentialsWEKIT.authToken,
-                        Version = "1.0.3",
-                    };
-                    break;
-            }
+			switch (client)
+			{
+				case "WEKIT":
+					xAPIClient = new ExperienceAPIClient
+					{
+						XApiEndpoint = new System.Uri("https://lrs.wekit-ecs.com/data/xAPI"),
+						AuthorizationToken = xAPICredentialsWEKIT.authToken,
+						Version = "1.0.3",
+					};
+					break;
+			}
 
-            return xAPIClient;
-        }
+#if UNITY_EDITOR
+			AppLog.LogInfo("Using fake web connector for xAPI calls since we are in the editor.", this);
+			xAPIClient.WebConnector = new XApiMockWebConnector();
+#endif
+
+			return xAPIClient;
+		}
 
 
-        private void ChangeXAPI(DBManager.LearningRecordStores selectedLRS)
-        {
-            try
-            {
-                ServiceManager.RemoveService<ExperienceService>();
-            }
-            catch (Exception ex)
-            {
-                AppLog.LogError($"[MirageXRServiceBootstrapper] Tried to unregister xAPI service via i5 ServiceManager, but failed to unregister: {ex.Message}");
-            }
+		private void ChangeXAPI(DBManager.LearningRecordStores selectedLRS)
+		{
+			try
+			{
+				ServiceManager.RemoveService<ExperienceService>();
+			}
+			catch (Exception ex)
+			{
+				AppLog.LogError($"[MirageXRServiceBootstrapper] Tried to unregister xAPI service via i5 ServiceManager, but failed to unregister: {ex.Message}");
+			}
 
-            switch (selectedLRS)
-            {
-                case DBManager.LearningRecordStores.WEKIT:
-                    ServiceManager.RegisterService(new ExperienceService(CreateXAPIClient("WEKIT")));
-                    break;
-            }
-        }
-    }
+			switch (selectedLRS)
+			{
+				case DBManager.LearningRecordStores.WEKIT:
+					ServiceManager.RegisterService(new ExperienceService(CreateXAPIClient("WEKIT")));
+					break;
+			}
+		}
+	}
 }


### PR DESCRIPTION
Closes #1740 .

This pull request redefines the xAPI behavior: When activating the service, the code checks whether the application is running in the Unity editor. In this case, the web connector in the xAPI client is replaced with a mocked web connector. It captures outgoing web calls and redirects them into console logs instead of sending them. This way, developer tests running in the Unity editor do not send xAPI statements anymore but the points at which they would be sent are still visible in the log.