### PR TITLE
Fixed download error for TutorialActivity.zip

### DIFF
--- a/Assets/MirageXR/Scripts/UI/NewUI/Tutorial.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/Tutorial.cs
@@ -18,7 +18,7 @@ public class TutorialModel
     public string id;
     public string message;
     public MessagePosition position = MessagePosition.Middle;
-    public string btnText = "Got it";
+    public string btnText = "Cancel";
 
     public bool HasId => !string.IsNullOrEmpty(id);
 


### PR DESCRIPTION
Fixed in editor and iOS download of TutorialActivity.zip from protected StreamingAssets folder, adjusting the path for  UnityWebRequest in editor, and fixing access right probs on iOS by reading the file stream read-only now. 

This is only tested in editor on Mac, and might require an additional "/" in line 323 of ActivityListView_v2.cs for in editor on Windows?

The iOS error should be resolved, but is not tested.

Btw: The code is not very elegant and would deserve to be rewritten.

Resolves #1767