### PR TITLE
Added caption string to the data model

### DIFF
--- a/Assets/MirageXR/DataModel/Activity.cs
+++ b/Assets/MirageXR/DataModel/Activity.cs
@@ -185,6 +185,7 @@ namespace MirageXR
         public float scale = 0f;
         public bool positionLock = false;
         public bool billboarded = true;
+        public string caption = string.Empty;//Stores caption from augmentation
 
         // NOT IN ARLEM SPEC. For the detect symbol.
         public float duration = 0f;


### PR DESCRIPTION
This commit adds a caption string to the data model. It allows the data model to store captions from augmentations with captions. The original commit (with other things) is 07b9861. 