### PR TITLE
fixed label's billboarding bug

### DIFF
--- a/Assets/MirageXR/ContentTypes/Label/Editor/Mobile/LabelEditorView.cs
+++ b/Assets/MirageXR/ContentTypes/Label/Editor/Mobile/LabelEditorView.cs
@@ -80,6 +80,7 @@ public class LabelEditorView : PopupEditorBase
     {
         _inputField.text = string.Empty;
         _toggleTrigger.isOn = false;
+        _isBillboarded = true;
         _gazeDuration = DEFAULT_SLIDER_VALUE;
         _txtGazeDurationValue.text = DEFAULT_SLIDER_VALUE.ToString("0");
 


### PR DESCRIPTION
code is now setting the default value for isBillboarding to true (in updateView) 
to be in line with the control panel setting, resolves #1791

https://github.com/WEKIT-ECS/MIRAGE-XR/assets/183296/5958c70b-4c11-47aa-8702-63de41b731d3
