### PR TITLE
#1788: action aug add rotation handles

### DIFF
--- a/Assets/MirageXR/ContentTypes/Action/GlyphItems.cs
+++ b/Assets/MirageXR/ContentTypes/Action/GlyphItems.cs
@@ -87,6 +87,9 @@ namespace MirageXR
             if (boundsControl != null)
             {
                 boundsControl.enabled = bounds;
+                boundsControl.RotationHandlesConfig.ShowHandleForX = bounds;
+                boundsControl.RotationHandlesConfig.ShowHandleForY = bounds;
+                boundsControl.RotationHandlesConfig.ShowHandleForZ = bounds;
             }
         }
     }

--- a/Assets/MirageXR/ContentTypes/Action/Glyphs/Allow.prefab
+++ b/Assets/MirageXR/ContentTypes/Action/Glyphs/Allow.prefab
@@ -26,11 +26,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1249071639867374}
   m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: -0, y: 0.13006982, z: 0.047869273}
+  m_LocalPosition: {x: 0, y: 0.0029245466, z: 0.0071}
   m_LocalScale: {x: 8.694114, y: 1.1370173, z: 8.694114}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4344669209980684}
+  m_Father: {fileID: 2606489436056553792}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &33446104436001548
@@ -114,8 +114,7 @@ Transform:
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 4919262433461562}
-  - {fileID: 4509004889423960}
+  - {fileID: 2606489436056553792}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -172,11 +171,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1762386426697898}
   m_LocalRotation: {x: 6.123234e-17, y: 1, z: -6.123234e-17, w: -6.123234e-17}
-  m_LocalPosition: {x: 0.0018114226, y: 0.13064528, z: 0.036404494}
+  m_LocalPosition: {x: 0.0018114226, y: 0.0035, z: -0.0043647774}
   m_LocalScale: {x: 1.0969888, y: 1.0969888, z: 1.0969888}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 4344669209980684}
+  m_Father: {fileID: 2606489436056553792}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &33062518449488206
@@ -229,3 +228,36 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &8136601992309537044
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2606489436056553792}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2606489436056553792
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8136601992309537044}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4919262433461562}
+  - {fileID: 4509004889423960}
+  m_Father: {fileID: 4344669209980684}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
Resolves #1788 by adding rotation handles to the boundary box around action glyphs.
Some of the glyphs may still have odd pivot points (I fixed 'allow' optically), but since we are going to replace them, I am not going through all of them now.