### PR TITLE
#1750 calibration rename button

### DIFF
--- a/Assets/MirageXR/Design/MobileUI/Prefabs/Calibration/Popup/CalibrationView.prefab
+++ b/Assets/MirageXR/Design/MobileUI/Prefabs/Calibration/Popup/CalibrationView.prefab
@@ -886,6 +886,11 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6804554404660861713, guid: 85d465c4591bc2d4498a09762b4f0df2,
+        type: 3}
+      propertyPath: m_text
+      value: Done
+      objectReference: {fileID: 0}
     - target: {fileID: 7554994448987104605, guid: 85d465c4591bc2d4498a09762b4f0df2,
         type: 3}
       propertyPath: m_RootOrder


### PR DESCRIPTION
Renamed the button on markerless calibration dialogue to "done" (instead of "apply"), because when the button appears, settings are already applied. Resolves #1750 