### PR TITLE
broken 3D model from sketchfab triggers gltfast error

### DIFF
--- a/Assets/MirageXR/ContentTypes/3DModel/Model.cs
+++ b/Assets/MirageXR/ContentTypes/3DModel/Model.cs
@@ -256,7 +256,7 @@ namespace MirageXR
 
             var renderers = model.GetComponentsInChildren<Renderer>();
             _colliders = new List<Bounds>();
-
+            
             // add colliders to meshes
             foreach (var r in renderers)
             {
@@ -278,15 +278,33 @@ namespace MirageXR
                     }
                     else
                     {
-                        // for all other types, add a mesh collider
-                        var newCollider = g.AddComponent<MeshCollider>();
-                        _colliders.Add(newCollider.bounds);
+                        if (IsMeshValid(r.GetComponent<MeshFilter>()))
+                        {
+                            var newCollider = g.AddComponent<MeshCollider>();
+                            _colliders.Add(newCollider.bounds);
+                        }
                     }
                 }
                 else
                 {
                     _colliders.Add(meshCollider.bounds);
                 }
+            }
+        }
+
+        private static bool IsMeshValid(MeshFilter meshFilter)
+        {
+            try
+            {
+                var value = UnityEngine.Debug.unityLogger.logEnabled;
+                UnityEngine.Debug.unityLogger.logEnabled = false;
+                var triangles = meshFilter.mesh.GetTriangles(0);
+                UnityEngine.Debug.unityLogger.logEnabled = value;
+                return triangles.Length != 0;
+            }
+            catch (Exception)
+            {
+                return false;
             }
         }
 


### PR DESCRIPTION
https://github.com/WEKIT-ECS/MIRAGE-XR/issues/1765

![image](https://github.com/WEKIT-ECS/MIRAGE-XR/assets/20320355/12f4c962-22ae-47e5-bf44-127950038e1a)


in case of a broken mesh, when adding MeshCollider (mc), mc will throw an exception. since wrapping it in 'try catch' will not work.

even if you just try to get “triangels” from the mesh, using “try catch” will not work because an error inside the method will be written to the log and the exception will not be thrown.

I added a check and reduced many errors to one, but I can’t completely get rid of them.