### PR TITLE
1366 - MoodleUrl and xAPI endpoint from ConfigParser

### DIFF
--- a/Assets/MirageXR/DataModel/ConfigParser.cs
+++ b/Assets/MirageXR/DataModel/ConfigParser.cs
@@ -38,8 +38,25 @@ namespace MirageXR
 
             var configItems = ConfigFile.text.Split(new[] { '\r', '\n' }).ToList();
 
-            MoodleUrl = configItems.FirstOrDefault(t => t.StartsWith("moodleUrl"))?.Split(":").LastOrDefault();
-            XApiUrl = configItems.FirstOrDefault(t => t.StartsWith("xApiUrl"))?.Split(":").LastOrDefault();
+            MoodleUrl = configItems.FirstOrDefault(t => t.StartsWith("moodleUrl"))?.Substring(10);
+            //PlayerPrefs.DeleteKey("MoodleURL"); // uncomment if you ever have to delete in editor for testing
+            if (!PlayerPrefs.HasKey("MoodleURL"))
+            {
+                Debug.LogTrace("[ConfigParser] No Moodle endpoint URL stored in PlayerPrefs, setting Moodle endpoint from brand configuration: " + MoodleUrl);
+                DBManager.domain = MoodleUrl;
+            } else
+            {
+                Debug.LogTrace("[ConfigParser] Moodle endpoint already stored in PlayerPrefs, ignoring Moodle endpoint from brand configuration: " + MoodleUrl);
+            }
+            XApiUrl = configItems.FirstOrDefault(t => t.StartsWith("xApiUrl"))?.Substring(8);
+            if (XApiUrl != "https://lrs.wekit-ecs.com/data/xAPI")
+            {
+                Debug.LogError("BrandConfiguration faulty: currently only https://lrs.wekit-ecs.com/data/xAPI supported as XApiUrl");
+            } else
+            {
+                Debug.LogTrace("[ConfigParser] xAPI endpoint URL from brand configuration: " + XApiUrl + " ignored as already set");
+                // would have to set DBManager.publicCurrentLearningRecordStore and send Eventmanager.XAPIChanged?.Invoke(DBManager.publicCurrentLearningRecordStore);
+            }
             PrimaryColor = configItems.FirstOrDefault(t => t.StartsWith("primaryColor"))?.Split(":").LastOrDefault();
             SecondaryColor = configItems.FirstOrDefault(t => t.StartsWith("secondaryColor"))?.Split(":").LastOrDefault();
             TextColor = configItems.FirstOrDefault(t => t.StartsWith("textColor"))?.Split(":").LastOrDefault();

--- a/Assets/MirageXR/Resources/MirageXRConfig.txt
+++ b/Assets/MirageXR/Resources/MirageXRConfig.txt
@@ -1,7 +1,7 @@
 companyName:WEKIT ECS
 productName:MirageXR
-moodleUrl:learn.wekit-ecs.com
-xApiUrl:lrs.wekit-ecs.com/data/xAPI
+moodleUrl:https://learn.wekit-ecs.com
+xApiUrl:https://lrs.wekit-ecs.com/data/xAPI
 version:$appVersion
 splashScreen:Assets/MirageXR/Logo/wekit-logo-v7.png
 logo:Assets/MirageXR/Logo/wekit-logo-v7.png

--- a/Assets/MirageXR/Services/Moodle/Login.cs
+++ b/Assets/MirageXR/Services/Moodle/Login.cs
@@ -6,6 +6,11 @@ using UnityEngine.UI;
 
 namespace MirageXR
 {
+    /// <summary>
+    /// Login View (Worldspace UI): This class is the interface to the prefab with
+    /// the UI elements for the login dialogue, including username/password/etc.,
+    /// Moodle and LRS configuration, and developer mode options.
+    /// </summary>
     public class Login : MonoBehaviour
     {
         [SerializeField] private GameObject loginCanvas;
@@ -33,6 +38,9 @@ namespace MirageXR
 
         public Text status;
 
+        /// <summary>
+        /// Initializes the view.
+        /// </summary>
         private void Start()
         {
             status.text = string.Empty;


### PR DESCRIPTION
The MirageXRConfig.txt was so far ignored, even though ConfigParser was already reading the values for MoodleUrl and XApiUrl. For MoodleUrl this is now resolved, and DBManager.domain is updated when the config is read and no PlayerPref is set. And a hook is now in place if we ever want to add another LRS.

This resolves #1366 