### PR TITLE
editor errors fix

### DIFF
--- a/Assets/CSE.MRTK.Toolkit/DebugConsole/Scripts/MainController.cs
+++ b/Assets/CSE.MRTK.Toolkit/DebugConsole/Scripts/MainController.cs
@@ -117,7 +117,7 @@ namespace CSE.MRTK.Toolkit.DebugConsole
         /// <param name="message">Message.</param>
         public void WriteMessage(string message)
         {
-            if (_dialogUI.gameObject.activeSelf)
+            if (_dialogUI != null && _dialogUI.gameObject.activeSelf)
             {
                 OnMessage?.Invoke(message);
             }

--- a/Assets/MirageXR/ContentTypes/Character/Scripts/FakeFloor.cs
+++ b/Assets/MirageXR/ContentTypes/Character/Scripts/FakeFloor.cs
@@ -21,8 +21,11 @@ namespace MirageXR
 
         private void OnDestroy()
         {
-            planeManager.onDetectionEnabled.RemoveListener(OnDetectionEnabled);
-            planeManager.onDetectionDisabled.RemoveListener(OnDetectionDisabled);
+            if (RootObject.Instance != null)
+            {
+                planeManager.onDetectionEnabled.RemoveListener(OnDetectionEnabled);
+                planeManager.onDetectionDisabled.RemoveListener(OnDetectionDisabled);   
+            }
         }
 
         private void Update()

--- a/Assets/MirageXR/Scripts/UI/NewUI/RootView_v2.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/RootView_v2.cs
@@ -105,7 +105,10 @@ public class RootView_v2 : BaseView
         EventManager.OnWorkplaceLoaded -= OnWorkplaceLoaded;
         EventManager.OnActivityStarted -= OnActivityLoaded;
         EventManager.OnMobileHelpPageChanged -= UpdateHelpPage;
-        RootObject.Instance.cameraCalibrationChecker.onAnchorLost.RemoveListener(ShowCalibrationAlert);
+        if (RootObject.Instance != null)
+        {
+            RootObject.Instance.cameraCalibrationChecker.onAnchorLost.RemoveListener(ShowCalibrationAlert);
+        }
     }
 
     private void OnWorkplaceLoaded()

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -39,7 +39,7 @@
     "com.unity.nuget.newtonsoft-json": "3.2.1",
     "com.unity.test-framework": "1.1.33",
     "com.unity.testtools.codecoverage": "1.2.4",
-    "com.unity.textmeshpro": "3.0.6",
+    "com.unity.textmeshpro": "3.0.8",
     "com.unity.timeline": "1.7.5",
     "com.unity.toolchain.macos-x86_64-linux-x86_64": "2.0.6",
     "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.6",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -216,7 +216,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.textmeshpro": {
-      "version": "3.0.6",
+      "version": "3.0.8",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
```
NullReferenceException: Object reference not set to an instance of an object
RootView_v2.OnDestroy () (at Assets/MirageXR/Scripts/UI/NewUI/RootView_v2.cs:108)
```

```
NullReferenceException: Object reference not set to an instance of an object
MirageXR.FakeFloor.OnDestroy () (at Assets/MirageXR/ContentTypes/Character/Scripts/FakeFloor.cs:24)
```

```
MissingReferenceException: The object of type 'FollowMeToggle' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.
CSE.MRTK.Toolkit.DebugConsole.MainController.WriteMessage (System.String message) (at Assets/CSE.MRTK.Toolkit/DebugConsole/Scripts/MainController.cs:120)
CSE.MRTK.Toolkit.DebugConsole.MainController.Application_logMessageReceived (System.String message, System.String stackTrace, UnityEngine.LogType type) (at Assets/CSE.MRTK.Toolkit/DebugConsole/Scripts/MainController.cs:110)
UnityEngine.Application.CallLogCallback (System.String logString, System.String stackTrace, UnityEngine.LogType type, System.Boolean invokedOnMainThread) (at /Users/bokken/build/output/unity/unity/Runtime/Export/Application/Application.cs:173)
```