### PR TITLE
1898 dead code detection (updated package)

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -23,7 +23,6 @@
     }
   ],
   "dependencies": {
-    "com.alexeyperov.unity-dependencies-hunter": "https://github.com/AlexeyPerov/Unity-Dependencies-Hunter.git#upm",
     "com.atteneder.gltfast": "6.2.0",
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
     "com.i5.toolkit.core": "1.9.2",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -23,6 +23,7 @@
     }
   ],
   "dependencies": {
+    "com.alexeyperov.unity-dependencies-hunter": "https://github.com/AlexeyPerov/Unity-Dependencies-Hunter.git#upm",
     "com.atteneder.gltfast": "6.2.0",
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
     "com.i5.toolkit.core": "1.9.2",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
+    "com.alexeyperov.unity-dependencies-hunter": {
+      "version": "https://github.com/AlexeyPerov/Unity-Dependencies-Hunter.git#upm",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "d2f8a0dd1b5b2e4c9b0a2f7ca8d3117fb01b4906"
+    },
     "com.atteneder.gltfast": {
       "version": "6.2.0",
       "depth": 0,

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,12 +1,5 @@
 {
   "dependencies": {
-    "com.alexeyperov.unity-dependencies-hunter": {
-      "version": "https://github.com/AlexeyPerov/Unity-Dependencies-Hunter.git#upm",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {},
-      "hash": "48c4858e14dee1f120a46bc4da79f50f2cb38faf"
-    },
     "com.atteneder.gltfast": {
       "version": "6.2.0",
       "depth": 0,


### PR DESCRIPTION
The package was fixed by maintainer AlexeyPerov for us, as the library require of the VisualScripting library is no longer supported by Unity (>=2022). 

Anyone running it, might want to edit the file DependenciesHunter.cs and uncomment the 
```
// #define HUNT_ADDRESSABLES
````