### PR TITLE
Silyasov/asset bugfix

### DIFF
--- a/Assets/MirageXR/ContentTypes/3DModel/Editors/Mobile/NewUI/3DModelEditor_v2.prefab
+++ b/Assets/MirageXR/ContentTypes/3DModel/Editors/Mobile/NewUI/3DModelEditor_v2.prefab
@@ -5125,8 +5125,9 @@ MonoBehaviour:
   _toggleLocal: {fileID: 3323495175604829532}
   _toggleSketchfab: {fileID: 8667426749044361931}
   _toggleLibraries: {fileID: 4966652972141602709}
-  _clientDataObject: {fileID: 0}
-  _clientDirectLoginDataObject: {fileID: 0}
+  _clientDataObject: {fileID: 11400000, guid: e4b7247f875394c6b9d4a73d95dc5370, type: 2}
+  _clientDirectLoginDataObject: {fileID: 11400000, guid: 66950305798884afe82b4adace2cfa8d,
+    type: 2}
   _localTab: {fileID: 4855544638988544474}
   _sketchfabTab: {fileID: 3725436933965692124}
   _librariesTab: {fileID: 948414644077357068}


### PR DESCRIPTION
I re-added the sketchfab token prefabs to the mobile editor panel prefab of the model augmentation. At least for me, these were dropped (and usually wouldn't be?).