### PR TITLE
Temporary camera rendering fix for URP

### DIFF
--- a/Assets/MirageXR/Managers/PlatformManager.cs
+++ b/Assets/MirageXR/Managers/PlatformManager.cs
@@ -105,7 +105,7 @@ namespace MirageXR
 #elif UNITY_WSA && !UNITY_EDITOR
             return DeviceFormat.Unknown;
 #else
-            return Screen.width > Screen.height ? DeviceFormat.Tablet : DeviceFormat.Unknown;
+            return Screen.width > Screen.height ? DeviceFormat.Tablet : DeviceFormat.Phone;
 #endif
         }
 

--- a/Assets/MirageXR/MirageXR.asmdef
+++ b/Assets/MirageXR/MirageXR.asmdef
@@ -27,7 +27,8 @@
         "GUID:a42927d1d4a3b4cda9b076a7adecb9cc",
         "GUID:dc960734dc080426fa6612f1c5fe95f3",
         "GUID:3248779d86bd31747b5d2214f30b01ac",
-        "GUID:7958db66189566541a6363568aee1575"
+        "GUID:7958db66189566541a6363568aee1575",
+        "GUID:15fc0a57446b3144c949da3e2b9737a9"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/MirageXR/Player/Scripts/RootObject.cs
+++ b/Assets/MirageXR/Player/Scripts/RootObject.cs
@@ -8,6 +8,7 @@ namespace MirageXR
     {
         public static RootObject Instance { get; private set; }
 
+        [SerializeField] private Camera _baseCamera;
         [SerializeField] private ImageTargetManagerWrapper _imageTargetManager;
         [SerializeField] private CalibrationManager _calibrationManager;
         [SerializeField] private FloorManagerWrapper _floorManager;
@@ -25,6 +26,8 @@ namespace MirageXR
         private EditorSceneService _editorSceneService;
         private WorkplaceManager _workplaceManager;
         private OpenAIManager _openAIManager;
+
+        public Camera baseCamera => _baseCamera;
 
         public ImageTargetManagerWrapper imageTargetManager => _imageTargetManager;
 
@@ -95,6 +98,7 @@ namespace MirageXR
 
             try
             {
+                _baseCamera ??= Camera.main;
                 _brandManager ??= new GameObject("BrandManager").AddComponent<BrandManager>();
                 _imageTargetManager ??= new GameObject("ImageTargetManagerWrapper").AddComponent<ImageTargetManagerWrapper>();
                 _calibrationManager ??= new GameObject("CalibrationManager").AddComponent<CalibrationManager>();

--- a/Assets/MirageXR/Scenes/Start.unity
+++ b/Assets/MirageXR/Scenes/Start.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44407052, g: 0.49331468, b: 0.57239574, a: 1}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1525,6 +1525,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e459b8393654410795d56ea44901509a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _baseCamera: {fileID: 807537243}
   _imageTargetManager: {fileID: 383528546}
   _calibrationManager: {fileID: 1209410220}
   _floorManager: {fileID: 547987041}

--- a/Assets/MirageXR/Scripts/UI/NewUI/ActivityListView_v2.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/ActivityListView_v2.cs
@@ -121,10 +121,10 @@ public class ActivityListView_v2 : BaseView
 
     public async void FetchAndUpdateView()
     {
-        LoadView.Instance.Show(true);
+        LoadView.Instance?.Show(true);
         _content = await FetchContent();
         UpdateView();
-        LoadView.Instance.Hide();
+        LoadView.Instance?.Hide();
     }
 
     public void UpdateView()

--- a/Assets/MirageXR/Scripts/UI/NewUI/RootView_v2.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/RootView_v2.cs
@@ -64,6 +64,7 @@ public class RootView_v2 : BaseView
 
     private async void Start()
     {
+        _viewCamera.SetupCameraPipeline();
         await _viewCamera.SetupFormat(PlatformManager.GetDeviceFormat());
         Initialization(null);
         EventManager.OnEditModeChanged += EditModeChangedForHelp;

--- a/Assets/MirageXR/Scripts/UI/NewUI/RootView_v2.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/RootView_v2.cs
@@ -64,7 +64,6 @@ public class RootView_v2 : BaseView
 
     private async void Start()
     {
-        _viewCamera.SetupCameraPipeline();
         await _viewCamera.SetupFormat(PlatformManager.GetDeviceFormat());
         Initialization(null);
         EventManager.OnEditModeChanged += EditModeChangedForHelp;

--- a/Assets/MirageXR/Scripts/UI/NewUI/ViewCamera.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/ViewCamera.cs
@@ -39,6 +39,7 @@ namespace MirageXR
             switch (deviceFormat)
             {
                 case DeviceFormat.Phone:
+                    SetupCameraPipeline();
                     await SetupViewForPortrait();
                     break;
                 case DeviceFormat.Tablet:

--- a/Assets/MirageXR/Scripts/UI/NewUI/ViewCamera.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/ViewCamera.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using UnityEngine;
+using UnityEngine.Rendering.Universal;
 
 namespace MirageXR
 {
@@ -25,6 +26,14 @@ namespace MirageXR
             _camera = GetComponent<Camera>();
         }
 
+        public void SetupCameraPipeline()
+        {
+            var uiCameraData = _camera.GetUniversalAdditionalCameraData();
+            uiCameraData.renderType = CameraRenderType.Overlay;
+            var baseCameraData = RootObject.Instance.baseCamera.GetUniversalAdditionalCameraData();
+            baseCameraData.cameraStack.Insert(0, _camera);
+        }
+        
         public async Task SetupFormat(DeviceFormat deviceFormat)
         {
             switch (deviceFormat)


### PR DESCRIPTION
Temporary fix to the camera renderer for URP at Fridolin's request. In portrait mode the ui camera will be placed in the base camera stack, in tablet mode both cameras will be base cameras and the blue background will remain under the ui.

![image](https://github.com/WEKIT-ECS/MIRAGE-XR/assets/20320355/1507d3e6-31eb-46ee-9b6e-56f90db49987)

![image](https://github.com/WEKIT-ECS/MIRAGE-XR/assets/20320355/f7cf2b9d-a885-4861-a574-1e486ffae0aa)
