### PR TITLE
#1970 on 1806 task station diamond make configurable

### DIFF
--- a/Assets/MirageXR/Design/3DModels/PlayerTaskStation.prefab
+++ b/Assets/MirageXR/Design/3DModels/PlayerTaskStation.prefab
@@ -24,6 +24,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 225183589405937360}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -31,7 +32,6 @@ Transform:
   m_Children:
   - {fileID: 7620666327346022297}
   m_Father: {fileID: 1564862708021636292}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &4557930885109773479
 MonoBehaviour:
@@ -70,13 +70,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1976844569128653719}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: -0.056900024, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2175097658723196317}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4384207315384949415
 GameObject:
@@ -101,13 +101,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4384207315384949415}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.45, y: -0.0321, z: 0.001}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1564862708021636292}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5804255884901617295
 GameObject:
@@ -132,13 +132,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5804255884901617295}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.226, y: 0, z: 0.001}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1564862708021636292}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &8514657620350876463
 GameObject:
@@ -163,19 +163,20 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8514657620350876463}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.0567, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1564862708021636292}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1314271721986968367
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 080088a3ed6793d46952dfa35f9bf0ac,
@@ -244,6 +245,57 @@ PrefabInstance:
       value: PlayerTaskStation
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 394859698401538911}
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7793767790642201852}
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1681593849130843029}
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2175097658723196317}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3968471894606619193}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -1853822903186390908}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1671793771436416733}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1899842224238348803}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2467590269829450743}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5090513018016203518}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8991036494466578457}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4907754109792769073}
   m_SourcePrefab: {fileID: 100100000, guid: 080088a3ed6793d46952dfa35f9bf0ac, type: 3}
 --- !u!23 &431411576981772203 stripped
 MeshRenderer:
@@ -271,9 +323,17 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2232750753583396478}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Radius: 0.05
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &-1853822903186390908
@@ -383,5 +443,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9aa67e79450bcf64aa38d00dd685e07b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4907754109792769073
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2232750753583396478}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c92e3e56dde4ba7b9b1ef6c25c688e9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/MirageXR/Design/MobileUI/Prefabs/Content.prefab
+++ b/Assets/MirageXR/Design/MobileUI/Prefabs/Content.prefab
@@ -338,7 +338,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1903019285016736729
 RectTransform:
   m_ObjectHideFlags: 0
@@ -427,6 +427,70 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &2943803932499054746
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5758967139271567716}
+  - component: {fileID: 2340284431227840047}
+  m_Layer: 5
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5758967139271567716
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2943803932499054746}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3986428680542946539}
+  - {fileID: 1007687912050602390}
+  m_Father: {fileID: 5585039221156229778}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 700, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2340284431227840047
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2943803932499054746}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 220
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &3824562618980430499
 GameObject:
   m_ObjectHideFlags: 0
@@ -1027,7 +1091,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &5585039221156229778
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1040,7 +1104,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 4273590172273696151}
+  - {fileID: 5758967139271567716}
+  - {fileID: 7617438744264513059}
   - {fileID: 3213806906070502249}
   m_Father: {fileID: 8469592056315964300}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1187,7 +1252,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 130}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &5699941831442526949
 MonoBehaviour:
@@ -1263,10 +1328,10 @@ RectTransform:
   - {fileID: 8998720987933112058}
   m_Father: {fileID: 2357885846016661659}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 100}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 360, y: -80}
+  m_SizeDelta: {x: 680, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8174211425821248813
 CanvasRenderer:
@@ -1476,6 +1541,536 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Back to Activity
+--- !u!1 &8093458174616525456
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3986428680542946539}
+  - component: {fileID: 8032082956942855360}
+  - component: {fileID: 2153473070221682002}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3986428680542946539
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8093458174616525456}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5758967139271567716}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 327.2584, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8032082956942855360
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8093458174616525456}
+  m_CullTransparentMesh: 1
+--- !u!114 &2153473070221682002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8093458174616525456}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Show step diamond
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: -1.4683685, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1001 &836167888895923300
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5585039221156229778}
+    m_Modifications:
+    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_text
+      value: 'Tie this action step to a real world location using computer vision:
+        take a photo of a distinct surface or view and MirageXR will track its location
+        to link all augmentations to it.'
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_fontAsset
+      value: 
+      objectReference: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee,
+        type: 2}
+    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_sharedMaterial
+      value: 
+      objectReference: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_VerticalAlignment
+      value: 256
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_HorizontalAlignment
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_hasFontAssetChanged
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501574, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_Name
+      value: Label
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 716.5413
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 254.853
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e54d6f23966cb5849bb1db7fb33ecfc1, type: 3}
+--- !u!224 &7617438744264513059 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
+    type: 3}
+  m_PrefabInstance: {fileID: 836167888895923300}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2263503595512512420
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 5758967139271567716}
+    m_Modifications:
+    - target: {fileID: 99353883667413507, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: _colorOn.b
+      value: 0.7019608
+      objectReference: {fileID: 0}
+    - target: {fileID: 99353883667413507, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: _colorOn.g
+      value: 0.24313726
+      objectReference: {fileID: 0}
+    - target: {fileID: 99353883667413507, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: _colorOn.r
+      value: 0.22745098
+      objectReference: {fileID: 0}
+    - target: {fileID: 99353883667413507, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: _colorOff.b
+      value: 0.1254902
+      objectReference: {fileID: 0}
+    - target: {fileID: 99353883667413507, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: _colorOff.g
+      value: 0.1254902
+      objectReference: {fileID: 0}
+    - target: {fileID: 99353883667413507, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: _colorOff.r
+      value: 0.1254902
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 170.7416
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 67.4439
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2316427036134989326, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_Text
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2316427036134989326, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758611293379111460, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_Text
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 2758611293379111460, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2898105642417349246, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: -33.047
+      objectReference: {fileID: 0}
+    - target: {fileID: 2898105642417349246, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -16.5236
+      objectReference: {fileID: 0}
+    - target: {fileID: 5710509426690689634, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 72
+      objectReference: {fileID: 0}
+    - target: {fileID: 5710509426690689634, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 72
+      objectReference: {fileID: 0}
+    - target: {fileID: 5710509426690689634, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -36.341
+      objectReference: {fileID: 0}
+    - target: {fileID: 6517995957319232082, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      propertyPath: m_Name
+      value: EditToggle
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 6517995957319232082, guid: ef26f63252657924ba000049dfc79a47,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 119601515142284809}
+  m_SourcePrefab: {fileID: 100100000, guid: ef26f63252657924ba000049dfc79a47, type: 3}
+--- !u!224 &1007687912050602390 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1339137362888527410, guid: ef26f63252657924ba000049dfc79a47,
+    type: 3}
+  m_PrefabInstance: {fileID: 2263503595512512420}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4980143691212936694 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6517995957319232082, guid: ef26f63252657924ba000049dfc79a47,
+    type: 3}
+  m_PrefabInstance: {fileID: 2263503595512512420}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &119601515142284809
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4980143691212936694}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ce563e4f16c14b5aa4b2d35a716a86a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  myToggle: {fileID: 5001784096940442367}
+--- !u!114 &5001784096940442367 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6485320514662497627, guid: ef26f63252657924ba000049dfc79a47,
+    type: 3}
+  m_PrefabInstance: {fileID: 2263503595512512420}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4980143691212936694}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2429296610961983762
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2127,168 +2722,6 @@ MonoBehaviour:
   _interactableObject: {fileID: 7668037678190994834}
   _isPartOfScrollView: 0
   _delay: 0
---- !u!1001 &6440967636542857168
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 5585039221156229778}
-    m_Modifications:
-    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_text
-      value: 'Tie this action step to a real world location using computer vision:
-        take a photo of a distinct surface or view and MirageXR will track its location
-        to link all augmentations to it.'
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_fontAsset
-      value: 
-      objectReference: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee,
-        type: 2}
-    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_sharedMaterial
-      value: 
-      objectReference: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_VerticalAlignment
-      value: 256
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_HorizontalAlignment
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501572, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_hasFontAssetChanged
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501574, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_Name
-      value: Label
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 716.5413
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 254.853
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 360
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -228.71324
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e54d6f23966cb5849bb1db7fb33ecfc1, type: 3}
---- !u!224 &4273590172273696151 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7074097757196501575, guid: e54d6f23966cb5849bb1db7fb33ecfc1,
-    type: 3}
-  m_PrefabInstance: {fileID: 6440967636542857168}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &8345802536847740666
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2360,7 +2793,7 @@ PrefabInstance:
     - target: {fileID: 6866726552229021075, guid: a5f4e0ce7b2a8f54396df8ada0dcb1e8,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6866726552229021075, guid: a5f4e0ce7b2a8f54396df8ada0dcb1e8,
         type: 3}
@@ -2370,7 +2803,7 @@ PrefabInstance:
     - target: {fileID: 6866726552229021075, guid: a5f4e0ce7b2a8f54396df8ada0dcb1e8,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6866726552229021075, guid: a5f4e0ce7b2a8f54396df8ada0dcb1e8,
         type: 3}
@@ -2420,12 +2853,12 @@ PrefabInstance:
     - target: {fileID: 6866726552229021075, guid: a5f4e0ce7b2a8f54396df8ada0dcb1e8,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 360
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6866726552229021075, guid: a5f4e0ce7b2a8f54396df8ada0dcb1e8,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -533.71326
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6866726552229021075, guid: a5f4e0ce7b2a8f54396df8ada0dcb1e8,
         type: 3}

--- a/Assets/MirageXR/Player/Resources/Prefabs/TaskStation~.prefab
+++ b/Assets/MirageXR/Player/Resources/Prefabs/TaskStation~.prefab
@@ -25,13 +25,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6724639185889768262}
+  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0.0289, y: -0.0144, z: 0}
   m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1564862708021636292}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &5158424378200672147
 MeshRenderer:
@@ -104,6 +104,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 080088a3ed6793d46952dfa35f9bf0ac,
@@ -172,6 +173,25 @@ PrefabInstance:
       value: TaskStation~
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: -8679921383154817045, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 485865061772007160}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3968471894606619193}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -2667454594048592969}
+    - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: 080088a3ed6793d46952dfa35f9bf0ac,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2056966098891455213}
   m_SourcePrefab: {fileID: 100100000, guid: 080088a3ed6793d46952dfa35f9bf0ac, type: 3}
 --- !u!4 &1564862708021636292 stripped
 Transform:
@@ -193,9 +213,17 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2232750753583396478}
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
   m_IsTrigger: 0
+  m_ProvidesContacts: 0
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_Radius: 0.0294657
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &-2667454594048592969

--- a/Assets/MirageXR/Scenes/Start.unity
+++ b/Assets/MirageXR/Scenes/Start.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44407052, g: 0.49331468, b: 0.57239574, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481676, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -371,6 +371,24 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1888399833}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &305906481 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3697567433863410390, guid: b27088da040df476b92f57a0cf3627c9,
+    type: 3}
+  m_PrefabInstance: {fileID: 328025326}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &305906483
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 305906481}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 89185a2ac7224155b66c7e1d7f5ac867, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &310166496
 GameObject:
   m_ObjectHideFlags: 0
@@ -415,6 +433,78 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1888399833}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &328025326
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1592552940681650009, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1592552940681650009, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1592552940681650009, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1592552940681650009, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1592552940681650009, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1592552940681650009, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1592552940681650009, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1592552940681650009, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1592552940681650009, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1592552940681650009, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3697567433863410390, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      propertyPath: m_Name
+      value: VisibilityManagerPrefab
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3697567433863410390, guid: b27088da040df476b92f57a0cf3627c9,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 305906483}
+  m_SourcePrefab: {fileID: 100100000, guid: b27088da040df476b92f57a0cf3627c9, type: 3}
 --- !u!1 &383528544
 GameObject:
   m_ObjectHideFlags: 0
@@ -1692,3 +1782,4 @@ SceneRoots:
   - {fileID: 1888399833}
   - {fileID: 890496492}
   - {fileID: 1378881399}
+  - {fileID: 328025326}

--- a/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/GameObjectVisibilityController.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/GameObjectVisibilityController.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+namespace MirageXR
+{
+    public class TaskStationVisibilityController : MonoBehaviour
+    {
+        private Renderer myRenderer;
+
+        void Awake()
+        {
+            myRenderer = GetComponentInChildren<Renderer>();
+            if (myRenderer == null)
+            {
+                Debug.LogError("No Renderer found in Game Object", this);
+                this.enabled = false;
+                return;
+            }
+            VisibilityManager.Instance.RegisterController(this);
+        }
+
+        void OnDestroy()
+        {
+            if (VisibilityManager.Instance != null)
+            {
+                VisibilityManager.Instance.UnregisterController(this);
+            }
+        }
+
+        public void SetVisibility(bool isVisible)
+        {
+            if (myRenderer != null)
+            {
+                myRenderer.enabled = isVisible;
+            }
+        }
+    }
+}

--- a/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/GameObjectVisibilityController.cs.meta
+++ b/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/GameObjectVisibilityController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7c92e3e56dde4ba7b9b1ef6c25c688e9
+timeCreated: 1714474184

--- a/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/ToggleVisibilityController.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/ToggleVisibilityController.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace MirageXR
+{
+    public class ToggleVisibilityController : MonoBehaviour
+    {
+        public Toggle myToggle;
+
+        void Start()
+        {
+            if (myToggle == null)
+            {
+                Debug.LogError("Toggle is not assigned.", this);
+                this.enabled = false;
+                return;
+            }
+
+            myToggle.isOn = true;
+
+            
+            myToggle.onValueChanged.AddListener(isOn => VisibilityManager.Instance.SetAllVisibility(isOn));
+        }
+    }
+}

--- a/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/ToggleVisibilityController.cs.meta
+++ b/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/ToggleVisibilityController.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ce563e4f16c14b5aa4b2d35a716a86a1
+timeCreated: 1714474247

--- a/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/VisibilityManager.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/VisibilityManager.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MirageXR
+{
+    public class VisibilityManager : MonoBehaviour
+    {
+        public static VisibilityManager Instance;
+
+        private List<TaskStationVisibilityController> controllers = new List<TaskStationVisibilityController>();
+
+        void Awake()
+        {
+            if (Instance != null)
+            {
+                Destroy(gameObject);
+            }
+            else
+            {
+                Instance = this;
+                DontDestroyOnLoad(gameObject);  // Optional, wenn der Manager über Szenen hinweg bestehen bleiben soll
+            }
+        }
+
+        public void RegisterController(TaskStationVisibilityController controller)
+        {
+            if (!controllers.Contains(controller))
+            {
+                controllers.Add(controller);
+            }
+        }
+
+        public void UnregisterController(TaskStationVisibilityController controller)
+        {
+            controllers.Remove(controller);
+        }
+
+        public void SetAllVisibility(bool isVisible)
+        {
+            foreach (var controller in controllers)
+            {
+                controller.SetVisibility(isVisible);
+            }
+        }
+    }
+}

--- a/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/VisibilityManager.cs
+++ b/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/VisibilityManager.cs
@@ -18,7 +18,7 @@ namespace MirageXR
             else
             {
                 Instance = this;
-                DontDestroyOnLoad(gameObject);  // Optional, wenn der Manager über Szenen hinweg bestehen bleiben soll
+                DontDestroyOnLoad(gameObject); 
             }
         }
 

--- a/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/VisibilityManager.cs.meta
+++ b/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/VisibilityManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 89185a2ac7224155b66c7e1d7f5ac867
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 600
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/VisibilityManagerPrefab.prefab
+++ b/Assets/MirageXR/Scripts/UI/NewUI/VisibilityManager/VisibilityManagerPrefab.prefab
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3697567433863410390
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1592552940681650009}
+  m_Layer: 0
+  m_Name: VisibilityManagerPrefab
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1592552940681650009
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3697567433863410390}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}


### PR DESCRIPTION
This pull request introduces a new 'Visibility Manager' feature that allows users to easily add or remove renderers from GameObjects via a toggle mechanism. Below are the key components of this implementation:

- **[VisibilityManager.cs](https://github.com/WEKIT-ECS/MIRAGE-XR/commit/76fe03b781c02d94e2e0e5bd42e463191f0a9b02#diff-fe19e2d84b964f17c2bad0ed737d01d0426359254039379fb8d2b9ed3915082d):** A central manager who handles the GameObjects that uses the prefab and stores a reference. 
- **[ToggleVisibilityController.cs](https://github.com/WEKIT-ECS/MIRAGE-XR/commit/76fe03b781c02d94e2e0e5bd42e463191f0a9b02#diff-6c1707644b960e8441c629dacc3a122472a1d9f4dfaa41a3117fcce4134aa145)**: Implements the function for a toggle, allowing it to be turned on or off. This toggle is designed to be user-friendly and responsive to interaction. 
- **[GameObjectVisibilityController.cs](https://github.com/WEKIT-ECS/MIRAGE-XR/commit/76fe03b781c02d94e2e0e5bd42e463191f0a9b02#diff-193d78314a54d8493a54807d0f41acbdf9031b782f48c8c50ebc708f75e2df25)**: Retrieves the renderer of a GameObject and registers the GameObjects during its lifecycle in the VisibilityManager.
- **[VisibilityManagerPrefab.prefab](https://github.com/WEKIT-ECS/MIRAGE-XR/commit/27f859f3a35c800397ee8ee4fd70776b87d2019e#diff-8c9cb6ae4facbf8edf34b3aa9b8c739a201750fcb7ac83f039749b41324273b7)**: Modifications were made to the existing menu to integrate the visibility toggle.


https://github.com/WEKIT-ECS/MIRAGE-XR/assets/69756846/f0508913-831d-4d42-aab6-8858b8ec04d7

