### PR TITLE
Fixing the caption field on top of other UI

### DIFF
--- a/Assets/MirageXR/ContentTypes/Audio/AudioPlayer.cs
+++ b/Assets/MirageXR/ContentTypes/Audio/AudioPlayer.cs
@@ -117,19 +117,26 @@ namespace MirageXR
             }
 
             var caption = obj.caption;
-            if (caption != string.Empty)
-            {
+            
                 StartCaptionDisplay(caption);
-            }
 
             // If all went well, return true.
             return true;
         }
 
+       
         private void StartCaptionDisplay(string caption)
         {
+            // Check if the caption string is empty or consists only of whitespace
+            if (string.IsNullOrWhiteSpace(caption))
+            {
+                return;  // If the caption is empty, return immediately and do nothing
+            }
+
+            // If the caption is not empty, proceed to display it
             StartCoroutine(DisplayCaptionWithDelay(caption));
         }
+
 
         private IEnumerator DisplayCaptionWithDelay(string fullCaption)
         {
@@ -224,7 +231,6 @@ namespace MirageXR
                 }
                 audioSource.mute = false;
                 audioSource.volume = 1.0f;
-                _captionObj.SetActive(true);
                 audioSource.Play();
                 isPlaying = true;
                 

--- a/Assets/MirageXR/ContentTypes/Audio/AudioPrefab.prefab
+++ b/Assets/MirageXR/ContentTypes/Audio/AudioPrefab.prefab
@@ -393,7 +393,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: New Text
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -716,7 +716,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &7913402268262665108
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This merge wants to fix the appearance of the caption field on the top of other UI when the audio prefab is active, but the caption is not generated. Now, the caption will be displayed only when it is generated.