### PR TITLE
Made submodules compatible with SSH and HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Packages/com.wekit-ecs.lib-lee"]
 	path = Packages/com.wekit-ecs.lib-lee
-	url = ../lib-lee.git
+	url = ../../WEKIT-ECS/lib-lee.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Packages/com.wekit-ecs.lib-lee"]
 	path = Packages/com.wekit-ecs.lib-lee
-	url = git@github.com:WEKIT-ECS/lib-lee.git
+	url = ../lib-lee.git


### PR DESCRIPTION
This pull request updates the submodule definition to use a relative path. This way, the project can still be checked out with SSH and HTTPS.

I included the WEKIT-ECS organization in the relative path. This way, any forks of MIRAGE-XR will still pull from our version of lib-lee instead of having to also fork it.

I tested these changes by cloning the project both with HTTPS and SSH and initializing the submodules for it. Git automatically uses the correct way to also pull the submodule.