### PR TITLE
Refined Player List and Sharing UI

### DIFF
--- a/Assets/MirageXR/Player/Scripts/Spatial/NewActivityScreenSpatialViewController.cs
+++ b/Assets/MirageXR/Player/Scripts/Spatial/NewActivityScreenSpatialViewController.cs
@@ -100,9 +100,19 @@ namespace MirageXR
 
         private void OnButtonCollaborativeSessionClicked()
         {
-            // TODO
-            MenuManager.Instance.ShowCollaborativeSessionPanelView();
-        }
+#if FUSION2
+            if (CollaborationManager.Instance.NetworkRunner.IsInSession)
+            {
+                MenuManager.Instance.ShowCollaborativeSessionSettingsPanelView();
+            }
+            else
+            {
+				MenuManager.Instance.ShowCollaborativeSessionPanelView();
+			}
+#else
+			MenuManager.Instance.ShowCollaborativeSessionPanelView();
+#endif
+		}
 
         private void OnButtonSettingsClicked()
         {

--- a/Assets/MirageXR/Player/Scripts/Spatial/Popups/CollaborativeSessionSettingsView.cs
+++ b/Assets/MirageXR/Player/Scripts/Spatial/Popups/CollaborativeSessionSettingsView.cs
@@ -52,6 +52,11 @@ namespace MirageXR
 		}
 
 #if FUSION2
+		private void OnDestroy()
+		{
+			CollaborationManager.Instance.UserManager.UserListChanged -= OnNetworkedUserDataListChanged;
+		}
+
 		private void OnNetworkedUserDataListChanged()
 		{
 			UpdatePlayerList();


### PR DESCRIPTION
This pull request implements two changes:

- It fixes error messages which appeared if the sharing menu is closed while a player is joining or leaving. It now unsubscribes from the player join/leave events once it is closed and re-initializes itself when it is opened again.
- The sharing button on the UI now skips the connection screen and immediately opens the settings window of the session if it is already connected. This way, it is possible to open and close the collaborative settings menu throughout the collaborative session. Previously, the menu could only be opened during the connection process and was lost once the user closes it.