### PR TITLE
RoomTwin improvements

### DIFF
--- a/Assets/MirageXR/Player/Scripts/Spatial/Popups/RoomScanSettingsSpatialView.cs
+++ b/Assets/MirageXR/Player/Scripts/Spatial/Popups/RoomScanSettingsSpatialView.cs
@@ -21,20 +21,39 @@ namespace MirageXR
             base.Initialization(onClose, args);
 
             _btnClose.onClick.AddListener(Close);
+
+            _toggleTwinVignette.isOn = (roomTwinManager.GetRoomTwinStyle() == RoomTwinStyle.TwinVignette);
+            _toggleFullTwin.isOn = (roomTwinManager.GetRoomTwinStyle() == RoomTwinStyle.FullTwin);
+
             _toggleTwinVignette.onValueChanged.AddListener(ToggleTwinVignetteValueChanged);
             _toggleFullTwin.onValueChanged.AddListener(ToggleFullTwinValueChanged);
+
         }
 
         private void ToggleFullTwinValueChanged(bool value)
         {
-            if (!value) return;
+            if (!value)
+            {
+                Debug.LogInfo("ToggleFullTwinValueChange: setting TwinVignette to on");
+                _toggleTwinVignette.isOn = true;
+                roomTwinManager.SetRoomTwinStyle(RoomTwinStyle.TwinVignette);
+                return;
+            }
             roomTwinManager.SetRoomTwinStyle(RoomTwinStyle.FullTwin);
+            _toggleTwinVignette.isOn = false;
         }
 
         private void ToggleTwinVignetteValueChanged(bool value)
         {
-            if (!value) return;
+            if (!value)
+            {
+                Debug.LogInfo("ToggleTwinVignetteValueChange: setting FullTwin to on");
+                _toggleFullTwin.isOn = true;
+                roomTwinManager.SetRoomTwinStyle(RoomTwinStyle.FullTwin);
+                return;
+            }
             roomTwinManager.SetRoomTwinStyle(RoomTwinStyle.TwinVignette);
+            _toggleFullTwin.isOn = false;
         }
     }
 }

--- a/Assets/MirageXR/Utility.UiKit/Prefabs/UI_KIT_Spatial/Screens/RoomScanStylePanel_Spatial.prefab
+++ b/Assets/MirageXR/Utility.UiKit/Prefabs/UI_KIT_Spatial/Screens/RoomScanStylePanel_Spatial.prefab
@@ -1133,10 +1133,15 @@ PrefabInstance:
       propertyPath: m_text
       value: Full twin
       objectReference: {fileID: 0}
+    - target: {fileID: 5319443648467790729, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_Name
+      value: ToggleFullTwin
+      objectReference: {fileID: 0}
     - target: {fileID: 7949123666628144448, guid: 1da20397547de4140bb334bb902d37a4,
         type: 3}
       propertyPath: m_IsOn
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -1285,10 +1290,20 @@ PrefabInstance:
       propertyPath: m_text
       value: Twin vignette
       objectReference: {fileID: 0}
+    - target: {fileID: 5319443648467790729, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_Name
+      value: ToggleTwinVignette
+      objectReference: {fileID: 0}
     - target: {fileID: 7949123666628144448, guid: 1da20397547de4140bb334bb902d37a4,
         type: 3}
       propertyPath: m_IsOn
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7949123666628144448, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_Interactable
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []


### PR DESCRIPTION
* fixed options in Room Scan Style panel
* reloading model now when switching room scan on
* an experiment with adding alpha transparency (that does not work it seems)
* implements basic crown wheel changes (which will be supported from PolySpatial 2 onwards)

resolves #2142, #2163, #2139