### PR TITLE
Avatar shutdown fixes

### DIFF
--- a/Assets/MirageXR/Networking/Scripts/HandsSynchronizer.cs
+++ b/Assets/MirageXR/Networking/Scripts/HandsSynchronizer.cs
@@ -108,6 +108,10 @@ namespace MirageXR
 		private void ApplyRemoteSingleHandDataToRig(bool isLeftSide)
 		{
 			HandController handController = AvatarRefs.OfflineReferences.GetSide(isLeftSide).HandController;
+			if (handController == null)
+			{
+				return;
+			}
 
 			_extractedData.HandSide = handController.JointsController.HandSide;
 			_extractedData.IsTracked = IsSideTracked(isLeftSide);

--- a/Assets/MirageXR/Networking/Scripts/NetworkedUserData.cs
+++ b/Assets/MirageXR/Networking/Scripts/NetworkedUserData.cs
@@ -62,8 +62,11 @@ namespace MirageXR
 
 		private void UnsubscribeFromLocalData()
 		{
-			_localUserDataSource.UserNameChanged -= OnLocalUserNameChanged;
-			_localUserDataSource.AvatarUrlChanged -= OnLocalAvatarUrlChanged;
+			if (_localUserDataSource != null)
+			{
+				_localUserDataSource.UserNameChanged -= OnLocalUserNameChanged;
+				_localUserDataSource.AvatarUrlChanged -= OnLocalAvatarUrlChanged;
+			}
 		}
 
 		private void OnLocalUserNameChanged(string newUserName)

--- a/Assets/MirageXR/Player/Scripts/Spatial/Popups/CollaborativeSessionSettingsView.cs
+++ b/Assets/MirageXR/Player/Scripts/Spatial/Popups/CollaborativeSessionSettingsView.cs
@@ -56,8 +56,11 @@ namespace MirageXR
 #if FUSION2
 		private void OnDestroy()
 		{
-			CollaborationManager.Instance.UserManager.UserListChanged -= OnNetworkedUserDataListChanged;
-			CollaborationManager.Instance.UserManager.AnyUserNameChanged -= OnAnyUserNameChanged;
+			if (CollaborationManager.Instance != null && CollaborationManager.Instance.UserManager != null)
+			{
+				CollaborationManager.Instance.UserManager.UserListChanged -= OnNetworkedUserDataListChanged;
+				CollaborationManager.Instance.UserManager.AnyUserNameChanged -= OnAnyUserNameChanged;
+			}
 		}
 
 		private void OnAnyUserNameChanged()


### PR DESCRIPTION
This pull request fixes some NullReferenceExceptions which occasionally happend when shutting down the application while still connected to a shared session. In these cases, the cleanup logic was trying to unregister from some events on MonoBehaviours that Unity sometimes had already destroyed.