### PR TITLE
Changes to the Avatar Deep Link Registration

### DIFF
--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarDeepLinkManager.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarDeepLinkManager.cs
@@ -42,7 +42,6 @@ namespace MirageXR
 			{
 				string avatarUrl = $"https://models.readyplayer.me/{id}.glb";
 				RootObject.Instance.AvatarLibraryManager.AddAvatar(avatarUrl);
-				RootObject.Instance.AvatarLibraryManager.Save();
 				if (setAvatar)
 				{
 					UserSettings.AvatarUrl = avatarUrl;

--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLibraryManager.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLibraryManager.cs
@@ -22,7 +22,7 @@ namespace MirageXR
 			Load();
 		}
 
-		private void OnDestroy()
+		private void OnDisable()
 		{
 			Save();
 		}


### PR DESCRIPTION
This pull request adjusts the deep link routine for loading avatars via deep links. It removes the Save() call for the AvatarLibraryManager so that no file access happens in code called via reflection.
To still ensure that the avatars are saved, the shutdown save method was adjusted to be run slightly earlier in an OnDisable method.