### PR TITLE
Tweaks for the Virtual Instructor

### DIFF
--- a/Assets/MirageXR/ContentTypes/VirtualInstructor/VirtualInstructorRPMInitializer.cs
+++ b/Assets/MirageXR/ContentTypes/VirtualInstructor/VirtualInstructorRPMInitializer.cs
@@ -32,6 +32,8 @@ namespace MirageXR
 				avatarReferences.Rig.IK.GetSide(i).Foot.Constraint.weight = 0;
 				avatarReferences.Rig.IK.GetSide(i).Foot.Target.GetComponent<FootController>().enabled = false;
 			}
+			TurnToUser turnToUser = avatar.AddComponent<TurnToUser>();
+			turnToUser.RotationOffset = Quaternion.Euler(0, 180, 0);
 			Animator animator = avatar.GetComponent<Animator>();
 			string animatorControllerPath = "ReadyPlayerMe/AnimatorController";
 			var handle = Addressables.LoadAssetAsync<RuntimeAnimatorController>(animatorControllerPath);

--- a/Assets/MirageXR/ContentTypes/VirtualInstructor/VirtualInstructorRPMInitializer.cs
+++ b/Assets/MirageXR/ContentTypes/VirtualInstructor/VirtualInstructorRPMInitializer.cs
@@ -14,6 +14,11 @@ namespace MirageXR
 
 		public override void InitializeAvatar(GameObject avatar)
 		{
+			AvatarVisibilityController visibilityController = gameObject.GetComponent<AvatarVisibilityController>();
+			visibilityController.FadeVisibility = false;
+			visibilityController.Visible = false;
+			visibilityController.FadeVisibility = true;
+			visibilityController.Visible = true;
 		}
 
 		public async override UniTask InitializeAvatarAsync(GameObject avatar)

--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLoader.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLoader.cs
@@ -173,7 +173,19 @@ namespace MirageXR
 				}
 				Destroy(CurrentAvatar);
 			}
+			if (!ContainerStillExists())
+			{
+				Debug.LogWarning("While loading the virtual instructor, its container has been deleted. Deleting the downloaded model to clean up orphaned 3D models.");
+				Destroy(e.Avatar);
+				return;
+			}
 			await SetupAvatarAsync(e);
+			if (!ContainerStillExists())
+			{
+				Debug.LogWarning("While loading the virtual instructor, its container has been deleted. Deleting the downloaded model to clean up orphaned 3D models.");
+				Destroy(e.Avatar);
+				return;
+			}
 			Loading = false;
 			AvatarLoaded?.Invoke(true);
 		}
@@ -199,6 +211,24 @@ namespace MirageXR
 			CurrentAvatar.transform.parent = transform;
 			CurrentAvatar.transform.localPosition = Vector3.zero;
 			CurrentAvatar.transform.localRotation = Quaternion.identity;
+		}
+
+		private bool ContainerStillExists()
+		{
+			// accessing the gameObject to check if it is null can also cause a MissingReferenceException if the container was already deleted
+			// so we are using a try-catch block here in addition to checking whether it is null
+			try
+			{
+				if (gameObject == null)
+				{
+					return false;
+				}
+				return true;
+			}
+			catch (MissingReferenceException ex)
+			{
+				return false;
+			}
 		}
 	}
 }

--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/TurnToUser.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/TurnToUser.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MirageXR
+{
+    public class TurnToUser : MonoBehaviour
+    {
+		// Reference to the main camera's Transform.
+		private Transform _camera;
+
+		// Flattened position of the camera (y-coordinate set to 0).
+		private Vector3 _flattenedCameraPos;
+		// Flattened position of this GameObject (y-coordinate set to 0).
+		private Vector3 _flattenedPos;
+
+		[field: SerializeField]
+		public Quaternion RotationOffset { get; set; }
+		[field: SerializeField]
+		public float RotationSpeed { get; set; } = 3f;
+
+		// Called when the script instance is being loaded.
+		// Initializes the reference to the main camera's Transform.
+		private void Start()
+		{
+			_camera = Camera.main.transform;
+		}
+
+		// Called every frame. Rotates the GameObject to face the user.
+		private void Update()
+		{
+			_flattenedCameraPos = new Vector3(_camera.position.x, 0, _camera.position.z);
+			_flattenedPos = new Vector3(transform.position.x, 0, transform.position.z);
+
+			Quaternion targetRotation = RotationOffset * Quaternion.LookRotation(_flattenedPos - _flattenedCameraPos, Vector3.up);
+
+			transform.rotation = Quaternion.Slerp(
+				transform.rotation,
+				targetRotation,
+				RotationSpeed * Time.deltaTime);
+		}
+	}
+}

--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/TurnToUser.cs.meta
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/TurnToUser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9282608bfeb7691468077b2810cffd07
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This pull request addresses the following aspects of the virtual instructor:

- The virtual instructor now turns towards the user.
- The fade-in effect of the avatars was also made available to the RPM models of the virtual instructor. Loaded virtual instructors now show the teleportation effect.
- Fixed an edge case where an orphaned downloaded RPM model would stay in the scene if the virtual instructor is deleted while the system is downloading a character.