### PR TITLE
Updated the deep link integration for the avatars to enable saving

### DIFF
--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarDeepLinkManager.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarDeepLinkManager.cs
@@ -1,6 +1,8 @@
 using i5.Toolkit.Core.DeepLinkAPI;
 using i5.Toolkit.Core.ServiceCore;
+using i5.Toolkit.Core.Utilities;
 using LearningExperienceEngine;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -11,25 +13,42 @@ namespace MirageXR
 	{
 		private const string avatarIdParameterName = "id";
 
-		void Start()
+		private void Awake()
 		{
-			if (!ServiceManager.ServiceExists<DeepLinkingService>())
+			Application.deepLinkActivated += OnDeepLinkActivated;
+			if (!string.IsNullOrEmpty(Application.absoluteURL))
 			{
-				ServiceManager.RegisterService<DeepLinkingService>(new DeepLinkingService());
+				OnDeepLinkActivated(Application.absoluteURL);
 			}
-			DeepLinkingService service = ServiceManager.GetService<DeepLinkingService>();
-
-			service.AddDeepLinkListener(this);
 		}
 
+		private void OnDeepLinkActivated(string url)
+		{
+			Debug.Log("Got deep link for " + url, this);
 
-		[DeepLink("avatar")]
+			Uri uri = new Uri(url);
+			string path = uri.Authority.ToLower();
+			Dictionary<string,string> fragments = UriUtils.GetUriParameters(uri);
+			DeepLinkArgs args = new DeepLinkArgs(fragments, uri);
+			if (path == "avatar")
+			{
+				ReceiveRPMAvatarUrl(args);
+			}
+			else if (path == "rpm")
+			{
+				ReceiveRPMUrl(args);
+			}
+			else
+			{
+				Debug.Log($"Deep link {url} was not processed by AvatarDeepLinkManager.", this);
+			}
+		}
+
 		public void ReceiveRPMAvatarUrl(DeepLinkArgs args)
 		{
 			ProcessRPMDeepLink(args, true);
 		}
 
-		[DeepLink("rpm")]
 		public void ReceiveRPMUrl(DeepLinkArgs args)
 		{
 			ProcessRPMDeepLink(args, false);
@@ -37,19 +56,21 @@ namespace MirageXR
 
 		private void ProcessRPMDeepLink(DeepLinkArgs args, bool setAvatar)
 		{
-			Debug.LogTrace("Received a deep link for a RPM model.");
+			Debug.LogTrace($"Received a deep link for a RPM model: {args.DeepLink}", this);
 			if (args.Parameters.TryGetValue(avatarIdParameterName, out string id))
 			{
 				string avatarUrl = $"https://models.readyplayer.me/{id}.glb";
 				RootObject.Instance.AvatarLibraryManager.AddAvatar(avatarUrl);
+				RootObject.Instance.AvatarLibraryManager.Save();
 				if (setAvatar)
 				{
+					Debug.LogTrace($"Set avatar to {id} based on deep link", this);
 					UserSettings.AvatarUrl = avatarUrl;
 				}
 			}
 			else
 			{
-				Debug.LogError("Recieved a deep link for a RPM model but it did not contain an id parameter: " + args.DeepLink);
+				Debug.LogError("Recieved a deep link for a RPM model but it did not contain an id parameter: " + args.DeepLink, this);
 			}
 		}
 	}

--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLibraryManager.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLibraryManager.cs
@@ -22,11 +22,6 @@ namespace MirageXR
 			Load();
 		}
 
-		private void OnDisable()
-		{
-			Save();
-		}
-
 		public void Load()
 		{
 			if (File.Exists(AvatarLibraryPath))


### PR DESCRIPTION
This pull request changes the point at which the avatar library saves imported avatars. They are now saved whenever a new ready player me gets added.

For this, the deep link structure was changed to not use reflection. This should ensure that no exception is created when accessing the file system invoked from a deep link on visionOS.