### PR TITLE
Switched avatar library saving from System.Text.Json to Newtonsoft

### DIFF
--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLibraryManager.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLibraryManager.cs
@@ -1,9 +1,9 @@
+using Newtonsoft.Json;
 using ReadyPlayerMe.Core;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Text.Json;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -27,14 +27,14 @@ namespace MirageXR
 			if (File.Exists(AvatarLibraryPath))
 			{
 				string json = File.ReadAllText(AvatarLibraryPath);
-				AvatarList = JsonSerializer.Deserialize<List<string>>(json);
+				AvatarList = JsonConvert.DeserializeObject<List<string>>(json);
 				_cachedAvatarThumbnails.Clear();
 			}
 		}
 
 		public void Save()
 		{
-			string json = JsonSerializer.Serialize<List<string>>(AvatarList);
+			string json = JsonConvert.SerializeObject(AvatarList);
 			File.WriteAllText(AvatarLibraryPath, json);
 		}
 


### PR DESCRIPTION
This pull request changes the saving routine from System.Text.Json to Newtonsoft.

The error message about saving seems to be created by the System.Text.Json library on VisonOS, so since the rest of the app works with Newtonsoft, I switched to the Newtonsoft Json library.