### PR TITLE
Reusable avatar library menu

### DIFF
--- a/Assets/MirageXR/ContentTypes/VirtualInstructor/Editors/SpatialUI/AddEditVirtualInstructor.prefab
+++ b/Assets/MirageXR/ContentTypes/VirtualInstructor/Editors/SpatialUI/AddEditVirtualInstructor.prefab
@@ -110,15 +110,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -785,15 +787,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1921,15 +1925,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 1
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -2554,15 +2560,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -3081,15 +3089,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 2
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -3365,15 +3375,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 2
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -4118,15 +4130,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 2
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -4291,15 +4305,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 3
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 1
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -4562,10 +4578,13 @@ MonoBehaviour:
   m_GlobalFontAsset: {fileID: 11400000, guid: b133eed21dbaf2648a34e5bb04e81b31, type: 2}
   m_OnFocusSelectAll: 1
   m_ResetOnDeActivation: 1
+  m_KeepTextSelectionVisible: 0
   m_RestoreOriginalTextOnEscape: 1
   m_isRichTextEditingAllowed: 0
   m_LineLimit: 0
+  isAlert: 0
   m_InputValidator: {fileID: 0}
+  m_ShouldActivateOnSelect: 1
 --- !u!1 &4366049125849881227
 GameObject:
   m_ObjectHideFlags: 0
@@ -4924,15 +4943,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -5255,15 +5276,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -5435,15 +5458,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -6281,15 +6306,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -7123,15 +7150,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -7266,7 +7295,6 @@ RectTransform:
   - {fileID: 4100459593135095089}
   - {fileID: 7189533072839639822}
   - {fileID: 3532681531442288779}
-  - {fileID: 7847322100565889198}
   - {fileID: 6249546850348682065}
   - {fileID: 3964979044856040850}
   - {fileID: 3834017587965952568}
@@ -7366,6 +7394,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
+  m_Resource: {fileID: 0}
   m_PlayOnAwake: 1
   m_Volume: 1
   m_Pitch: 1
@@ -8249,15 +8278,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -8599,15 +8630,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 2
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -9739,6 +9772,11 @@ PrefabInstance:
       propertyPath: m_text
       value: Trigger
       objectReference: {fileID: 0}
+    - target: {fileID: 4402199868842319173, guid: e12c0d1b070d27a428c2925fb2b12141,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 6936238326413488191, guid: e12c0d1b070d27a428c2925fb2b12141,
         type: 3}
       propertyPath: m_Name
@@ -9914,6 +9952,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_fontStyle
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311985367779728598, guid: a1b011872f6be4df592787dec5d7e04f,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
@@ -10856,16 +10899,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2868886488254015350, guid: bf7d55a09be4e4e0591dd7985ec12309,
         type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: bf7d55a09be4e4e0591dd7985ec12309,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: bf7d55a09be4e4e0591dd7985ec12309,
-        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0.5
       objectReference: {fileID: 0}
@@ -11039,6 +11072,11 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -22
       objectReference: {fileID: 0}
+    - target: {fileID: 6921493601685152821, guid: bf7d55a09be4e4e0591dd7985ec12309,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 272
+      objectReference: {fileID: 0}
     - target: {fileID: 7275240436571798741, guid: bf7d55a09be4e4e0591dd7985ec12309,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -11069,11 +11107,53 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -136
       objectReference: {fileID: 0}
+    - target: {fileID: 7310920228524560600, guid: bf7d55a09be4e4e0591dd7985ec12309,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7310920228524560600, guid: bf7d55a09be4e4e0591dd7985ec12309,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7310920228524560600, guid: bf7d55a09be4e4e0591dd7985ec12309,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 202
+      objectReference: {fileID: 0}
+    - target: {fileID: 7310920228524560600, guid: bf7d55a09be4e4e0591dd7985ec12309,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 272
+      objectReference: {fileID: 0}
+    - target: {fileID: 7310920228524560600, guid: bf7d55a09be4e4e0591dd7985ec12309,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 101
+      objectReference: {fileID: 0}
+    - target: {fileID: 7310920228524560600, guid: bf7d55a09be4e4e0591dd7985ec12309,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -136
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: bf7d55a09be4e4e0591dd7985ec12309, type: 3}
+--- !u!114 &191153681841826562 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1473191029720978687, guid: bf7d55a09be4e4e0591dd7985ec12309,
+    type: 3}
+  m_PrefabInstance: {fileID: 1645729408322846717}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3be587e0de54e41f1822f8f47737b65f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &2596310329586606459 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3661774287444958854, guid: bf7d55a09be4e4e0591dd7985ec12309,
@@ -12622,6 +12702,11 @@ PrefabInstance:
       propertyPath: m_text
       value: Add new avatar
       objectReference: {fileID: 0}
+    - target: {fileID: 2741558825775370105, guid: d4a6c6e3889e34f5683658d4dffa615c,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -14000,6 +14085,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 4167863870277494094}
     m_Modifications:
+    - target: {fileID: 744396591797449423, guid: 7ff37d196692745c988ec777cd812985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 1424780595457329277, guid: 7ff37d196692745c988ec777cd812985,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -14019,6 +14109,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1593655244171781860, guid: 7ff37d196692745c988ec777cd812985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 1892975063716399786, guid: 7ff37d196692745c988ec777cd812985,
         type: 3}
@@ -14170,6 +14265,16 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4598719997269947012, guid: 7ff37d196692745c988ec777cd812985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 5100247034399100136, guid: 7ff37d196692745c988ec777cd812985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 6189910831156920297, guid: 7ff37d196692745c988ec777cd812985,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -14215,6 +14320,11 @@ PrefabInstance:
       propertyPath: addEditVirtualInstructor
       value: 
       objectReference: {fileID: 6549462736254134430}
+    - target: {fileID: 7819917889198549237, guid: 7ff37d196692745c988ec777cd812985,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -14927,6 +15037,11 @@ PrefabInstance:
       propertyPath: m_text
       value: Apply
       objectReference: {fileID: 0}
+    - target: {fileID: 1983271889404353239, guid: 4686fb69716f24d80bc38f29ee81ab8f,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 5450898656251003128, guid: 4686fb69716f24d80bc38f29ee81ab8f,
         type: 3}
       propertyPath: m_Name
@@ -15342,6 +15457,11 @@ PrefabInstance:
       propertyPath: m_text
       value: Path settings
       objectReference: {fileID: 0}
+    - target: {fileID: 5487136758858801812, guid: caf90974ea4164cb3940b3d18ff3f716,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 5971792678921206086, guid: caf90974ea4164cb3940b3d18ff3f716,
         type: 3}
       propertyPath: m_text
@@ -15356,6 +15476,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_fontSizeBase
       value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 5971792678921206086, guid: caf90974ea4164cb3940b3d18ff3f716,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 6249933623200909455, guid: caf90974ea4164cb3940b3d18ff3f716,
         type: 3}
@@ -15526,287 +15651,6 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 5303727425498288071}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &5419832356292868056
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 4167863870277494094}
-    m_Modifications:
-    - target: {fileID: 61257076460960869, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 61257076460960869, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 61257076460960869, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 226
-      objectReference: {fileID: 0}
-    - target: {fileID: 61257076460960869, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -203
-      objectReference: {fileID: 0}
-    - target: {fileID: 67469114172767788, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 67469114172767788, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 67469114172767788, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 290
-      objectReference: {fileID: 0}
-    - target: {fileID: 67469114172767788, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 226
-      objectReference: {fileID: 0}
-    - target: {fileID: 1424780595457329277, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1424780595457329277, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1424780595457329277, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 226
-      objectReference: {fileID: 0}
-    - target: {fileID: 1424780595457329277, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -198
-      objectReference: {fileID: 0}
-    - target: {fileID: 1892975063716399786, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1892975063716399786, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1892975063716399786, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 226
-      objectReference: {fileID: 0}
-    - target: {fileID: 1892975063716399786, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -42
-      objectReference: {fileID: 0}
-    - target: {fileID: 1976723320526228332, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1976723320526228332, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1976723320526228332, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 226
-      objectReference: {fileID: 0}
-    - target: {fileID: 1976723320526228332, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -266
-      objectReference: {fileID: 0}
-    - target: {fileID: 2782676072868575070, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_Name
-      value: CharacterSettings
-      objectReference: {fileID: 0}
-    - target: {fileID: 2782676072868575070, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 452
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 286
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 517
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8917745672115560626, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8917745672115560626, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8917745672115560626, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 226
-      objectReference: {fileID: 0}
-    - target: {fileID: 8917745672115560626, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -239
-      objectReference: {fileID: 0}
-    - target: {fileID: 9137806295007279692, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9137806295007279692, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9137806295007279692, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 226
-      objectReference: {fileID: 0}
-    - target: {fileID: 9137806295007279692, guid: 34d294a449cb6402b85453b0eb183c19,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -122
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 34d294a449cb6402b85453b0eb183c19, type: 3}
---- !u!114 &191153681841826562 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5300738491291901146, guid: 34d294a449cb6402b85453b0eb183c19,
-    type: 3}
-  m_PrefabInstance: {fileID: 5419832356292868056}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3be587e0de54e41f1822f8f47737b65f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!224 &7847322100565889198 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
-    type: 3}
-  m_PrefabInstance: {fileID: 5419832356292868056}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5480531926914184961
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -15845,6 +15689,11 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: -30
       objectReference: {fileID: 0}
+    - target: {fileID: 5487136758858801812, guid: caf90974ea4164cb3940b3d18ff3f716,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 5971792678921206086, guid: caf90974ea4164cb3940b3d18ff3f716,
         type: 3}
       propertyPath: m_text
@@ -15859,6 +15708,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_fontSizeBase
       value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 5971792678921206086, guid: caf90974ea4164cb3940b3d18ff3f716,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 6249933623200909455, guid: caf90974ea4164cb3940b3d18ff3f716,
         type: 3}
@@ -16387,6 +16241,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_fontStyle
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2311985367779728598, guid: a1b011872f6be4df592787dec5d7e04f,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
@@ -17936,6 +17795,11 @@ PrefabInstance:
       propertyPath: _noCharacterSelectedText
       value: Set character model
       objectReference: {fileID: 0}
+    - target: {fileID: 1879515266705915738, guid: 8ed70138b742ab140baaaa735bc4f83b,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 5658132884886014261, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_Name
@@ -18345,6 +18209,11 @@ PrefabInstance:
       propertyPath: m_fontStyle
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2311985367779728598, guid: a1b011872f6be4df592787dec5d7e04f,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_Pivot.x
@@ -18733,6 +18602,11 @@ PrefabInstance:
       propertyPath: m_HorizontalAlignment
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 7960123485719434009, guid: 7f9686d3825704428b6404d181397b79,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 9011441108467284886, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_Name
@@ -18878,6 +18752,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_text
       value: Loop animation
+      objectReference: {fileID: 0}
+    - target: {fileID: 4402199868842319173, guid: e12c0d1b070d27a428c2925fb2b12141,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 6936238326413488191, guid: e12c0d1b070d27a428c2925fb2b12141,
         type: 3}
@@ -19027,6 +18906,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_fontSizeBase
       value: 17
+      objectReference: {fileID: 0}
+    - target: {fileID: 7960123485719434009, guid: 7f9686d3825704428b6404d181397b79,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 9011441108467284886, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}

--- a/Assets/MirageXR/ContentTypes/VirtualInstructor/Editors/SpatialUI/ReplaceModel/AvatarModelSettingsPanel.prefab
+++ b/Assets/MirageXR/ContentTypes/VirtualInstructor/Editors/SpatialUI/ReplaceModel/AvatarModelSettingsPanel.prefab
@@ -34,13 +34,14 @@ RectTransform:
   - {fileID: 919190020271811524}
   - {fileID: 3069876102758860273}
   - {fileID: 3185274679788343711}
+  - {fileID: 8804968223313391443}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 17.217163, y: -791.68}
   m_SizeDelta: {x: 452, y: 811.841}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &9155928542051502093
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -62,7 +63,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   addNewCharacter: {fileID: 3788685834449748279}
-  addCharacterPanel: {fileID: 0}
+  addCharacterPanel: {fileID: 1473191029720978687}
   thumbnailGrid: {fileID: 6921493601685152821}
   characterThumbnailPrefab: {fileID: 7603192885245916981, guid: 276a63b6c957a2044924d34718c7dcd4,
     type: 3}
@@ -105,7 +106,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -0.00024414062, y: -0.041137695}
+  m_AnchoredPosition: {x: -0.00024414062, y: -0.00024414062}
   m_SizeDelta: {x: 420, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &1728422839308457098
@@ -646,6 +647,11 @@ PrefabInstance:
       propertyPath: m_fontSizeBase
       value: 19
       objectReference: {fileID: 0}
+    - target: {fileID: 3913455080168857287, guid: abac81157a3e04f47bd7572063d05fcc,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 8799103945160162359, guid: abac81157a3e04f47bd7572063d05fcc,
         type: 3}
       propertyPath: m_Pivot.x
@@ -770,10 +776,20 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1297709106702404371, guid: 9e83402e428764b40814587c2b0671f6,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 2280490040156435836, guid: 9e83402e428764b40814587c2b0671f6,
         type: 3}
       propertyPath: m_IsActive
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3769795780851785914, guid: 9e83402e428764b40814587c2b0671f6,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 7603192885245916981, guid: 9e83402e428764b40814587c2b0671f6,
         type: 3}
@@ -924,6 +940,11 @@ PrefabInstance:
         type: 3}
       propertyPath: _noCharacterSelectedText
       value: Add new character
+      objectReference: {fileID: 0}
+    - target: {fileID: 1879515266705915738, guid: 8ed70138b742ab140baaaa735bc4f83b,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 5658132884886014261, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
@@ -1222,6 +1243,287 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 5796565270077336479}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6764920101108844581
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2868886488254015350}
+    m_Modifications:
+    - target: {fileID: 61257076460960869, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 61257076460960869, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 61257076460960869, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 226
+      objectReference: {fileID: 0}
+    - target: {fileID: 61257076460960869, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -203
+      objectReference: {fileID: 0}
+    - target: {fileID: 67469114172767788, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 67469114172767788, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 67469114172767788, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 290
+      objectReference: {fileID: 0}
+    - target: {fileID: 67469114172767788, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 226
+      objectReference: {fileID: 0}
+    - target: {fileID: 1424780595457329277, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1424780595457329277, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1424780595457329277, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 226
+      objectReference: {fileID: 0}
+    - target: {fileID: 1424780595457329277, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -198
+      objectReference: {fileID: 0}
+    - target: {fileID: 1892975063716399786, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1892975063716399786, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1892975063716399786, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 226
+      objectReference: {fileID: 0}
+    - target: {fileID: 1892975063716399786, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -42
+      objectReference: {fileID: 0}
+    - target: {fileID: 1976723320526228332, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1976723320526228332, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1976723320526228332, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 226
+      objectReference: {fileID: 0}
+    - target: {fileID: 1976723320526228332, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -266
+      objectReference: {fileID: 0}
+    - target: {fileID: 2782676072868575070, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_Name
+      value: CharacterSettings
+      objectReference: {fileID: 0}
+    - target: {fileID: 2782676072868575070, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 452
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 286
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8917745672115560626, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8917745672115560626, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8917745672115560626, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 226
+      objectReference: {fileID: 0}
+    - target: {fileID: 8917745672115560626, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -239
+      objectReference: {fileID: 0}
+    - target: {fileID: 9137806295007279692, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9137806295007279692, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9137806295007279692, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 226
+      objectReference: {fileID: 0}
+    - target: {fileID: 9137806295007279692, guid: 34d294a449cb6402b85453b0eb183c19,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -122
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 34d294a449cb6402b85453b0eb183c19, type: 3}
+--- !u!114 &1473191029720978687 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5300738491291901146, guid: 34d294a449cb6402b85453b0eb183c19,
+    type: 3}
+  m_PrefabInstance: {fileID: 6764920101108844581}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3be587e0de54e41f1822f8f47737b65f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &8804968223313391443 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2868886488254015350, guid: 34d294a449cb6402b85453b0eb183c19,
+    type: 3}
+  m_PrefabInstance: {fileID: 6764920101108844581}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7362528734659350033
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1290,10 +1592,20 @@ PrefabInstance:
       propertyPath: m_text
       value: Libraries
       objectReference: {fileID: 0}
+    - target: {fileID: 5014023781860353152, guid: 6823da54dee7c4311895fa9dcf3b4f17,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 5651719979295437882, guid: 6823da54dee7c4311895fa9dcf3b4f17,
         type: 3}
       propertyPath: m_text
       value: Libraries
+      objectReference: {fileID: 0}
+    - target: {fileID: 5651719979295437882, guid: 6823da54dee7c4311895fa9dcf3b4f17,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 6196459137689129869, guid: 6823da54dee7c4311895fa9dcf3b4f17,
         type: 3}
@@ -1304,6 +1616,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_text
       value: My characters
+      objectReference: {fileID: 0}
+    - target: {fileID: 6972251928464813709, guid: 6823da54dee7c4311895fa9dcf3b4f17,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 8009088525922751876, guid: 6823da54dee7c4311895fa9dcf3b4f17,
         type: 3}

--- a/Assets/MirageXR/Player/Scripts/Spatial/Popups/ChangeUserAvatarView.cs
+++ b/Assets/MirageXR/Player/Scripts/Spatial/Popups/ChangeUserAvatarView.cs
@@ -16,8 +16,13 @@ namespace MirageXR
 		[SerializeField] private RectTransform _confirmationPanel;
 		[SerializeField] private Button _closeWindowBtn;
 		[SerializeField] private Button _openEditorBtn;
-		[SerializeField] private Button _applyAvatarBtn;
-		[SerializeField] private TMP_InputField _avatarUrlField;
+		[SerializeField] private CharacterModelSelectionElement _characterModelSelectionElement;
+
+		[Header("Prefabs")]
+		[SerializeField] private GameObject _avatarLibraryMenu;
+
+		private ReplaceModel _avatarLibraryMenuInstance;
+		private RectTransform _rectTransform;
 
 		protected override bool TryToGetArguments(params object[] args)
 		{
@@ -27,24 +32,58 @@ namespace MirageXR
 		public override void Initialization(Action<PopupBase> onClose, params object[] args)
 		{
 			base.Initialization(onClose, args);
+			
+			_rectTransform = GetComponent<RectTransform>();
 
 			_closeWindowBtn.onClick.AddListener(Close);
 			_openEditorBtn.onClick.AddListener(OpenEditor);
-			_applyAvatarBtn.onClick.AddListener(ApplyAvatarUrl);
+			//_applyAvatarBtn.onClick.AddListener(ApplyAvatarUrl);
+			_characterModelSelectionElement.CharacterModelSelectionStarted += OpenAvatarLibrary;
+
+			//_avatarUrlField.text = UserSettings.AvatarUrl;
+
+			// add the current avatar to the library so that it can be loaded
+			if (!RootObject.Instance.AvatarLibraryManager.ContainsAvatar(UserSettings.AvatarUrl))
+			{
+				RootObject.Instance.AvatarLibraryManager.AddAvatar(UserSettings.AvatarUrl);
+			}
+
 			UserSettings.AvatarUrlChanged += OnAvatarUrlChanged;
 
-			_avatarUrlField.text = UserSettings.AvatarUrl;
+			ApplyAvatarUrl();
 		}
 
 		private void OnDestroy()
 		{
+			_characterModelSelectionElement.CharacterModelSelectionStarted -= OpenAvatarLibrary;
 			UserSettings.AvatarUrlChanged -= OnAvatarUrlChanged;
+		}
+
+		private void OpenAvatarLibrary()
+		{
+			if (_avatarLibraryMenuInstance == null)
+			{
+				_avatarLibraryMenuInstance = Instantiate(_avatarLibraryMenu, transform).GetComponent<ReplaceModel>();
+				_avatarLibraryMenuInstance.CharacterModelSelected += OnAvatarSelected;
+			}
+			RectTransform avatarLibraryMenuRectTransform = _avatarLibraryMenuInstance.GetComponent<RectTransform>();
+			avatarLibraryMenuRectTransform.localPosition = new Vector3(
+				_rectTransform.sizeDelta.x + avatarLibraryMenuRectTransform.sizeDelta.x / 2f + 20,
+				0,
+				0);
+			_avatarLibraryMenuInstance.gameObject.SetActive(true);
+		}
+
+		private void OnAvatarSelected(string modelUrl)
+		{
+			UserSettings.AvatarUrl = modelUrl;
 		}
 
 		private void OnAvatarUrlChanged(string newAvatarUrl)
 		{
-			_avatarUrlField.text = UserSettings.AvatarUrl;
-			StartCoroutine(ShowConfirmationPanel());
+			//_avatarUrlField.text = UserSettings.AvatarUrl;
+			//StartCoroutine(ShowConfirmationPanel());
+			ApplyAvatarUrl();
 		}
 
 		private void OpenEditor()
@@ -54,13 +93,14 @@ namespace MirageXR
 
 		private void ApplyAvatarUrl()
 		{
-			if (!string.IsNullOrEmpty(_avatarUrlField.text))
-			{
-				UserSettings.AvatarUrl = _avatarUrlField.text;
-				Debug.LogDebug("Changed avatar url to " + UserSettings.AvatarUrl);
+			//if (!string.IsNullOrEmpty(_avatarUrlField.text))
+			//{
+			//	UserSettings.AvatarUrl = _avatarUrlField.text;
+			//	Debug.LogDebug("Changed avatar url to " + UserSettings.AvatarUrl);
 
-				StartCoroutine(ShowConfirmationPanel());
-			}
+			//	StartCoroutine(ShowConfirmationPanel());
+			//}
+			_characterModelSelectionElement.Thumbnail.CharacterModelUrl = UserSettings.AvatarUrl;
 		}
 
 		private IEnumerator ShowConfirmationPanel()

--- a/Assets/MirageXR/Player/Scripts/Spatial/Popups/ChangeUserAvatarView.cs
+++ b/Assets/MirageXR/Player/Scripts/Spatial/Popups/ChangeUserAvatarView.cs
@@ -13,7 +13,6 @@ namespace MirageXR
 	public class ChangeUserAvatarView : PopupBase
 	{
 		[Header("References")]
-		[SerializeField] private RectTransform _confirmationPanel;
 		[SerializeField] private Button _closeWindowBtn;
 		[SerializeField] private Button _openEditorBtn;
 		[SerializeField] private CharacterModelSelectionElement _characterModelSelectionElement;
@@ -37,10 +36,7 @@ namespace MirageXR
 
 			_closeWindowBtn.onClick.AddListener(Close);
 			_openEditorBtn.onClick.AddListener(OpenEditor);
-			//_applyAvatarBtn.onClick.AddListener(ApplyAvatarUrl);
 			_characterModelSelectionElement.CharacterModelSelectionStarted += OpenAvatarLibrary;
-
-			//_avatarUrlField.text = UserSettings.AvatarUrl;
 
 			// add the current avatar to the library so that it can be loaded
 			if (!RootObject.Instance.AvatarLibraryManager.ContainsAvatar(UserSettings.AvatarUrl))
@@ -59,6 +55,7 @@ namespace MirageXR
 			UserSettings.AvatarUrlChanged -= OnAvatarUrlChanged;
 		}
 
+		// opens the avatar library menu (creates the menu instance if it did not already exist)
 		private void OpenAvatarLibrary()
 		{
 			if (_avatarLibraryMenuInstance == null)
@@ -67,6 +64,7 @@ namespace MirageXR
 				_avatarLibraryMenuInstance.CharacterModelSelected += OnAvatarSelected;
 			}
 			RectTransform avatarLibraryMenuRectTransform = _avatarLibraryMenuInstance.GetComponent<RectTransform>();
+			// place next to this menu
 			avatarLibraryMenuRectTransform.localPosition = new Vector3(
 				_rectTransform.sizeDelta.x + avatarLibraryMenuRectTransform.sizeDelta.x / 2f + 20,
 				0,
@@ -74,40 +72,30 @@ namespace MirageXR
 			_avatarLibraryMenuInstance.gameObject.SetActive(true);
 		}
 
+		// called if the user selected an avatar from the library view
+		// applies the selected avatar to the user settings
+		// this automatically invokes an event that the avatar was changed and this will update the UI
 		private void OnAvatarSelected(string modelUrl)
 		{
 			UserSettings.AvatarUrl = modelUrl;
 		}
 
+		// called if a new avatar was set in the user settings
 		private void OnAvatarUrlChanged(string newAvatarUrl)
 		{
-			//_avatarUrlField.text = UserSettings.AvatarUrl;
-			//StartCoroutine(ShowConfirmationPanel());
 			ApplyAvatarUrl();
 		}
 
+		// opens the ReadyPlayerMe editor website
 		private void OpenEditor()
 		{
 			Application.OpenURL(UserSettings.READYPLAYERME_EDITOR_URL);
 		}
 
+		// apply the currently saved AvatarUrl to the UI to reflect the selected avatar
 		private void ApplyAvatarUrl()
 		{
-			//if (!string.IsNullOrEmpty(_avatarUrlField.text))
-			//{
-			//	UserSettings.AvatarUrl = _avatarUrlField.text;
-			//	Debug.LogDebug("Changed avatar url to " + UserSettings.AvatarUrl);
-
-			//	StartCoroutine(ShowConfirmationPanel());
-			//}
 			_characterModelSelectionElement.Thumbnail.CharacterModelUrl = UserSettings.AvatarUrl;
-		}
-
-		private IEnumerator ShowConfirmationPanel()
-		{
-			_confirmationPanel.gameObject.SetActive(true);
-			yield return new WaitForSeconds(3f);
-			_confirmationPanel.gameObject.SetActive(false);
 		}
 	}
 }

--- a/Assets/MirageXR/Player/Scripts/Spatial/Popups/ChangeUserAvatarView.cs
+++ b/Assets/MirageXR/Player/Scripts/Spatial/Popups/ChangeUserAvatarView.cs
@@ -16,6 +16,7 @@ namespace MirageXR
 		[SerializeField] private Button _closeWindowBtn;
 		[SerializeField] private Button _openEditorBtn;
 		[SerializeField] private CharacterModelSelectionElement _characterModelSelectionElement;
+		[SerializeField] private Button _replaceModelBtn;
 
 		[Header("Prefabs")]
 		[SerializeField] private GameObject _avatarLibraryMenu;
@@ -36,6 +37,7 @@ namespace MirageXR
 
 			_closeWindowBtn.onClick.AddListener(Close);
 			_openEditorBtn.onClick.AddListener(OpenEditor);
+			_replaceModelBtn.onClick.AddListener(OpenAvatarLibrary);
 			_characterModelSelectionElement.CharacterModelSelectionStarted += OpenAvatarLibrary;
 
 			// add the current avatar to the library so that it can be loaded

--- a/Assets/MirageXR/Prefabs/SpatialScreens/Popups/ChangeUserAvatar.prefab
+++ b/Assets/MirageXR/Prefabs/SpatialScreens/Popups/ChangeUserAvatar.prefab
@@ -1,5 +1,42 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &36714558876431512
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9105071082040306256}
+  m_Layer: 5
+  m_Name: BottomContent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9105071082040306256
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 36714558876431512}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3875912433766751761}
+  - {fileID: 8116156631587317280}
+  m_Father: {fileID: 831870524671889656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -250}
+  m_SizeDelta: {x: 420, y: 380}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &343772831513821657
 GameObject:
   m_ObjectHideFlags: 0
@@ -75,7 +112,7 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &947192471921783397
+--- !u!1 &1755765500498743820
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -83,132 +120,34 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1040754579559279494}
-  - component: {fileID: 83691303033724881}
-  - component: {fileID: 8568245781272916644}
-  m_Layer: 0
-  m_Name: Text (TMP)
+  - component: {fileID: 3875912433766751761}
+  m_Layer: 5
+  m_Name: CharacterChipBox
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1040754579559279494
+--- !u!224 &3875912433766751761
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 947192471921783397}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_GameObject: {fileID: 1755765500498743820}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4784306993177320642}
+  m_Children:
+  - {fileID: 2953338260653742333}
+  m_Father: {fileID: 9105071082040306256}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 15, y: -15}
-  m_SizeDelta: {x: 390, y: 16}
-  m_Pivot: {x: 0, y: 1}
---- !u!222 &83691303033724881
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 947192471921783397}
-  m_CullTransparentMesh: 1
---- !u!114 &8568245781272916644
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 947192471921783397}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Paste the generated avatar link of the ReadyPlayerMe editor
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 2ee51921491a242a0814e2e7f65ae568, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 2ee51921491a242a0814e2e7f65ae568, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4289703855
-  m_fontColor: {r: 0.6862745, g: 0.6862745, b: 0.6862745, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 13
-  m_fontSizeBase: 13
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0.000061035156}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 420, y: 304}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!1 &2332111798119249222
 GameObject:
   m_ObjectHideFlags: 0
@@ -284,214 +223,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 3.7
---- !u!1 &2443624414658375827
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6397247848871995362}
-  - component: {fileID: 3340943888756993076}
-  - component: {fileID: 7153040495029454163}
-  - component: {fileID: 5762731325420940956}
-  m_Layer: 5
-  m_Name: Line
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &6397247848871995362
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2443624414658375827}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8650483005974409184}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 1}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &3340943888756993076
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2443624414658375827}
-  m_CullTransparentMesh: 1
---- !u!114 &7153040495029454163
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2443624414658375827}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.101960786}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &5762731325420940956
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2443624414658375827}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreLayout: 1
-  m_MinWidth: -1
-  m_MinHeight: -1
-  m_PreferredWidth: -1
-  m_PreferredHeight: -1
-  m_FlexibleWidth: -1
-  m_FlexibleHeight: -1
-  m_LayoutPriority: 1
---- !u!1 &2503102038276092505
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2996231424777603399}
-  m_Layer: 5
-  m_Name: ApplyButton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2996231424777603399
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2503102038276092505}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5768943999579513399}
-  - {fileID: 187424075770644340}
-  m_Father: {fileID: 1827170526410056169}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 420, y: 64}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &2602096688971754956
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8968634827063762212}
-  - component: {fileID: 4287627889579615144}
-  - component: {fileID: 873934415071233573}
-  m_Layer: 5
-  m_Name: Background
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8968634827063762212
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2602096688971754956}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6154737258735268083}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0}
-  m_AnchorMax: {x: 0.5, y: 0}
-  m_AnchoredPosition: {x: -209.76196, y: 0}
-  m_SizeDelta: {x: 420, y: 32.6282}
-  m_Pivot: {x: 0, y: 0}
---- !u!222 &4287627889579615144
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2602096688971754956}
-  m_CullTransparentMesh: 1
---- !u!114 &873934415071233573
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2602096688971754956}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.49411768, g: 0.28627452, b: 0.75294125, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: a8e90fed5a50440e890a91deacf1e649, type: 3}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 100
 --- !u!1 &3094301985059019969
 GameObject:
   m_ObjectHideFlags: 0
@@ -526,6 +257,43 @@ RectTransform:
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 420, y: 6}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3225161419562899521
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4750266513614051076}
+  m_Layer: 5
+  m_Name: Header
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4750266513614051076
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3225161419562899521}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8211057028540568377}
+  - {fileID: 8459057659774925696}
+  m_Father: {fileID: 831870524671889656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: -30}
+  m_SizeDelta: {x: 420, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &4983834706231715171
 GameObject:
@@ -596,13 +364,13 @@ RectTransform:
   m_Children:
   - {fileID: 5764171882107036858}
   - {fileID: 3719514645108809969}
-  - {fileID: 1827170526410056169}
+  - {fileID: 831870524671889656}
   - {fileID: 7820014643193127613}
   m_Father: {fileID: 8473332119307211519}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 226, y: 0}
+  m_AnchoredPosition: {x: 226, y: -0}
   m_SizeDelta: {x: 452, y: 0}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &4790313542487879427
@@ -815,6 +583,81 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 420, y: 76}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &6341503039141729659
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8459057659774925696}
+  - component: {fileID: 8494050705304575062}
+  - component: {fileID: 2305880493312245740}
+  m_Layer: 5
+  m_Name: Line
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8459057659774925696
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6341503039141729659}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4750266513614051076}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8494050705304575062
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6341503039141729659}
+  m_CullTransparentMesh: 1
+--- !u!114 &2305880493312245740
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6341503039141729659}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.101960786}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &6482717499299899896
 GameObject:
   m_ObjectHideFlags: 0
@@ -851,7 +694,7 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: -30}
   m_SizeDelta: {x: 0, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &6571380932576369425
+--- !u!1 &7072779924649360202
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -859,294 +702,36 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 6154737258735268083}
-  - component: {fileID: 3629673511266140250}
-  - component: {fileID: 7269370475081353449}
-  - component: {fileID: 6988932342735248314}
+  - component: {fileID: 831870524671889656}
   m_Layer: 5
-  m_Name: Confirmation
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &6154737258735268083
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6571380932576369425}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8968634827063762212}
-  - {fileID: 3993233648201619070}
-  - {fileID: 2015322687953273987}
-  m_Father: {fileID: 1827170526410056169}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 210, y: -30}
-  m_SizeDelta: {x: 420, y: 60}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &3629673511266140250
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6571380932576369425}
-  m_CullTransparentMesh: 1
---- !u!114 &7269370475081353449
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6571380932576369425}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.49411765, g: 0.2901961, b: 0.7529412, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: a8e90fed5a50440e890a91deacf1e649, type: 3}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 3.7
---- !u!95 &6988932342735248314
-Animator:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6571380932576369425}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 0}
-  m_CullingMode: 0
-  m_UpdateMode: 2
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!1 &6848569973133939942
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1827170526410056169}
-  - component: {fileID: 4440830115824100608}
-  - component: {fileID: 8924823814063489538}
-  - component: {fileID: 1932767984143909122}
-  - component: {fileID: 7629277405059686348}
-  m_Layer: 5
-  m_Name: CustomLinkOpen
+  m_Name: AvatarPanel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1827170526410056169
+--- !u!224 &831870524671889656
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6848569973133939942}
+  m_GameObject: {fileID: 7072779924649360202}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 6154737258735268083}
-  - {fileID: 8650483005974409184}
-  - {fileID: 4784306993177320642}
-  - {fileID: 2996231424777603399}
+  - {fileID: 1302756267822070534}
+  - {fileID: 4750266513614051076}
+  - {fileID: 9105071082040306256}
   m_Father: {fileID: 6994616335414442954}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 226, y: -272}
-  m_SizeDelta: {x: 420, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &4440830115824100608
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6848569973133939942}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 1
-  m_Spacing: 0
-  m_ChildForceExpandWidth: 0
-  m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
---- !u!222 &8924823814063489538
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6848569973133939942}
-  m_CullTransparentMesh: 1
---- !u!114 &1932767984143909122
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6848569973133939942}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.1764706, g: 0.1764706, b: 0.1764706, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: a8e90fed5a50440e890a91deacf1e649, type: 3}
-  m_Type: 1
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 3.7
---- !u!114 &7629277405059686348
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6848569973133939942}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalFit: 2
-  m_VerticalFit: 1
---- !u!1 &7045606100195169496
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3993233648201619070}
-  - component: {fileID: 5405574159436626722}
-  - component: {fileID: 4417429123552739219}
-  m_Layer: 5
-  m_Name: Image
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &3993233648201619070
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7045606100195169496}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6154737258735268083}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 26, y: 0}
-  m_SizeDelta: {x: 30, y: 30}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &5405574159436626722
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7045606100195169496}
-  m_CullTransparentMesh: 1
---- !u!114 &4417429123552739219
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7045606100195169496}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 6d088b9527f6c834e8047dc7ac589ad5, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 420, y: 456}
+  m_Pivot: {x: 0.5, y: 1}
 --- !u!1 &7661867713572801471
 GameObject:
   m_ObjectHideFlags: 0
@@ -1178,9 +763,9 @@ RectTransform:
   - {fileID: 3565699655242152014}
   m_Father: {fileID: 8473332119307211519}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 226, y: -535}
   m_SizeDelta: {x: 452, y: 80}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!1 &7759137196896082122
@@ -1194,7 +779,6 @@ GameObject:
   - component: {fileID: 8473332119307211519}
   - component: {fileID: 4606671233562244267}
   - component: {fileID: 2788274786266869286}
-  - component: {fileID: 4792947105233587671}
   - component: {fileID: 2988074005164678959}
   m_Layer: 0
   m_Name: ChangeUserAvatar
@@ -1249,32 +833,6 @@ MonoBehaviour:
   background: {fileID: 2462220581496004286}
   shadow: {fileID: 7701711896392029012}
   content: {fileID: 6994616335414442954}
---- !u!114 &4792947105233587671
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7759137196896082122}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 1
-  m_Spacing: -87
-  m_ChildForceExpandWidth: 0
-  m_ChildForceExpandHeight: 0
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
 --- !u!114 &2988074005164678959
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1287,11 +845,87 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b780291dd4dd6c84b8228b1136908a28, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _confirmationPanel: {fileID: 6154737258735268083}
+  _confirmationPanel: {fileID: 0}
   _closeWindowBtn: {fileID: 1661849700783613301}
   _openEditorBtn: {fileID: 8832294078494451603}
-  _applyAvatarBtn: {fileID: 6301879107561777034}
-  _avatarUrlField: {fileID: 8767111325646621741}
+  _characterModelSelectionElement: {fileID: 8727372479419648274}
+  _avatarLibraryMenu: {fileID: 2782676072868575070, guid: bf7d55a09be4e4e0591dd7985ec12309,
+    type: 3}
+--- !u!1 &7793655198397837752
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1302756267822070534}
+  - component: {fileID: 8499375330016156451}
+  - component: {fileID: 1080694810317968998}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1302756267822070534
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7793655198397837752}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 831870524671889656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 440}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &8499375330016156451
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7793655198397837752}
+  m_CullTransparentMesh: 1
+--- !u!114 &1080694810317968998
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7793655198397837752}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.29803923}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a8e90fed5a50440e890a91deacf1e649, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 3.7
 --- !u!1 &7943334003811696997
 GameObject:
   m_ObjectHideFlags: 0
@@ -1328,7 +962,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 452, y: 400}
+  m_SizeDelta: {x: 452, y: 619.89}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &4839538626081025748
 CanvasRenderer:
@@ -1388,176 +1022,6 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
---- !u!1 &7976752918891129713
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5768943999579513399}
-  - component: {fileID: 6214843842490547545}
-  - component: {fileID: 2686427916580969008}
-  - component: {fileID: 6406907047568261298}
-  m_Layer: 5
-  m_Name: Line
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &5768943999579513399
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7976752918891129713}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2996231424777603399}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 1}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &6214843842490547545
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7976752918891129713}
-  m_CullTransparentMesh: 1
---- !u!114 &2686427916580969008
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7976752918891129713}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.101960786}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &6406907047568261298
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7976752918891129713}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreLayout: 1
-  m_MinWidth: -1
-  m_MinHeight: -1
-  m_PreferredWidth: -1
-  m_PreferredHeight: -1
-  m_FlexibleWidth: -1
-  m_FlexibleHeight: -1
-  m_LayoutPriority: 1
---- !u!1 &8060532624365068735
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8650483005974409184}
-  m_Layer: 5
-  m_Name: TopContent
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &8650483005974409184
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8060532624365068735}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8637717160870969003}
-  - {fileID: 6397247848871995362}
-  m_Father: {fileID: 1827170526410056169}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 420, y: 60}
-  m_Pivot: {x: 1, y: 1}
---- !u!1 &8474115616040916284
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4784306993177320642}
-  m_Layer: 5
-  m_Name: Input
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &4784306993177320642
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8474115616040916284}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1040754579559279494}
-  - {fileID: 6134115550848489610}
-  m_Father: {fileID: 1827170526410056169}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 420, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &614308300872983803
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1675,6 +1139,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_text
       value: Set your avatar
+      objectReference: {fileID: 0}
+    - target: {fileID: 2741558825775370105, guid: d4a6c6e3889e34f5683658d4dffa615c,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -2009,6 +1478,11 @@ PrefabInstance:
       propertyPath: m_text
       value: Open Ready Player Me Editor
       objectReference: {fileID: 0}
+    - target: {fileID: 8267509774586390693, guid: f4a921e9d72124e9d99d3138c02bcef4,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 8475254793657031064, guid: f4a921e9d72124e9d99d3138c02bcef4,
         type: 3}
       propertyPath: m_Sprite
@@ -2240,625 +1714,462 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1126832654870880162}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1386412599756606663
+--- !u!1001 &1911288893403366640
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 8650483005974409184}
+    m_TransformParent: {fileID: 9105071082040306256}
     m_Modifications:
-    - target: {fileID: 374395229811981668, guid: f4a921e9d72124e9d99d3138c02bcef4,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 374395229811981668, guid: f4a921e9d72124e9d99d3138c02bcef4,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 374395229811981668, guid: f4a921e9d72124e9d99d3138c02bcef4,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 374395229811981668, guid: f4a921e9d72124e9d99d3138c02bcef4,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: 374395229811981668, guid: f4a921e9d72124e9d99d3138c02bcef4,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 374395229811981668, guid: f4a921e9d72124e9d99d3138c02bcef4,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 374395229811981668, guid: f4a921e9d72124e9d99d3138c02bcef4,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
-      objectReference: {fileID: 0}
-    - target: {fileID: 6814163434785011136, guid: f4a921e9d72124e9d99d3138c02bcef4,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_Pivot.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
-        type: 3}
-      propertyPath: m_AnchorMax.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_AnchorMin.x
-      value: 0.5
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 420
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 60
+      value: 76
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 210
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -342
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8267509774586390693, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7960123485719434009, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_text
-      value: Avatar Link
+      value: Replace model
       objectReference: {fileID: 0}
-    - target: {fileID: 8475254793657031064, guid: f4a921e9d72124e9d99d3138c02bcef4,
+    - target: {fileID: 7960123485719434009, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300004, guid: 20f25674b9512834f88938d45ed495d7,
-        type: 3}
-    - target: {fileID: 8604682539884885447, guid: f4a921e9d72124e9d99d3138c02bcef4,
-        type: 3}
-      propertyPath: m_Name
-      value: Text_Item
+      propertyPath: m_fontSize
+      value: 17
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: 9204784105788219323, guid: f4a921e9d72124e9d99d3138c02bcef4, type: 3}
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: f4a921e9d72124e9d99d3138c02bcef4, type: 3}
---- !u!224 &8637717160870969003 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7269604847431463532, guid: f4a921e9d72124e9d99d3138c02bcef4,
-    type: 3}
-  m_PrefabInstance: {fileID: 1386412599756606663}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1674544394147963669
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 2996231424777603399}
-    m_Modifications:
-    - target: {fileID: 1237036768041626613, guid: 2935dd84022e6413985ff381bbe18b5a,
+    - target: {fileID: 7960123485719434009, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
-      propertyPath: m_text
-      value: Apply
-      objectReference: {fileID: 0}
-    - target: {fileID: 1237036768041626613, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_fontColor.b
+      propertyPath: m_margin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1237036768041626613, guid: 2935dd84022e6413985ff381bbe18b5a,
+    - target: {fileID: 7960123485719434009, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
-      propertyPath: m_fontColor.g
+      propertyPath: m_margin.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1237036768041626613, guid: 2935dd84022e6413985ff381bbe18b5a,
+    - target: {fileID: 7960123485719434009, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
-      propertyPath: m_fontColor.r
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1237036768041626613, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_fontColor32.rgba
-      value: 4278190080
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 32
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
+      propertyPath: m_fontStyle
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
+    - target: {fileID: 7960123485719434009, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
+      propertyPath: m_fontSizeBase
+      value: 17
       objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
+    - target: {fileID: 7960123485719434009, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
+      propertyPath: m_HorizontalAlignment
+      value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
+    - target: {fileID: 7960123485719434009, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4857772689248406853, guid: 2935dd84022e6413985ff381bbe18b5a,
+    - target: {fileID: 9011441108467284886, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_Name
-      value: ApplyButton
+      value: PurpelBtnText_Spatial
       objectReference: {fileID: 0}
-    - target: {fileID: 4857772689248406853, guid: 2935dd84022e6413985ff381bbe18b5a,
+    - target: {fileID: 9011441108467284886, guid: 7f9686d3825704428b6404d181397b79,
         type: 3}
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7580807843204146417, guid: 2935dd84022e6413985ff381bbe18b5a,
-        type: 3}
-      propertyPath: m_Color.a
-      value: 1
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2935dd84022e6413985ff381bbe18b5a, type: 3}
---- !u!224 &187424075770644340 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 7f9686d3825704428b6404d181397b79, type: 3}
+--- !u!224 &8116156631587317280 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1559635757074080865, guid: 2935dd84022e6413985ff381bbe18b5a,
+  m_CorrespondingSourceObject: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,
     type: 3}
-  m_PrefabInstance: {fileID: 1674544394147963669}
+  m_PrefabInstance: {fileID: 1911288893403366640}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &6301879107561777034 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4632489782547793055, guid: 2935dd84022e6413985ff381bbe18b5a,
-    type: 3}
-  m_PrefabInstance: {fileID: 1674544394147963669}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &4116245127218390127
+--- !u!1001 &6177376167822278182
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 4784306993177320642}
+    m_TransformParent: {fileID: 4750266513614051076}
     m_Modifications:
-    - target: {fileID: 2013265710687290654, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2311985367779728598, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_text
-      value: Enter text
+      value: Add or replace the 3D model of the virtual instructor.
       objectReference: {fileID: 0}
-    - target: {fileID: 2182287188719179075, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2311985367779728598, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
-      propertyPath: m_Name
-      value: InputField_Name_Spatial
-      objectReference: {fileID: 0}
-    - target: {fileID: 5275781622059831158, guid: 2f0bf0095de7c42219e099d9ffcb8672,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: -0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
-        type: 3}
-      propertyPath: m_Pivot.y
+      propertyPath: m_fontStyle
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2311985367779728598, guid: a1b011872f6be4df592787dec5d7e04f,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_AnchorMax.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_AnchorMin.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_SizeDelta.x
       value: 390
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_SizeDelta.y
       value: 44
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 195
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 20
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+    - target: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3702743543327962201, guid: a1b011872f6be4df592787dec5d7e04f,
+        type: 3}
+      propertyPath: m_Name
+      value: GrayUnderlinedText_Spatial
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 2f0bf0095de7c42219e099d9ffcb8672, type: 3}
---- !u!224 &6134115550848489610 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: a1b011872f6be4df592787dec5d7e04f, type: 3}
+--- !u!224 &8211057028540568377 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7799978048887913701, guid: 2f0bf0095de7c42219e099d9ffcb8672,
+  m_CorrespondingSourceObject: {fileID: 2614896178023640351, guid: a1b011872f6be4df592787dec5d7e04f,
     type: 3}
-  m_PrefabInstance: {fileID: 4116245127218390127}
+  m_PrefabInstance: {fileID: 6177376167822278182}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &8767111325646621741 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4662596080531171394, guid: 2f0bf0095de7c42219e099d9ffcb8672,
-    type: 3}
-  m_PrefabInstance: {fileID: 4116245127218390127}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &5467744000483316316
+--- !u!1001 &8728483302703126768
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 6154737258735268083}
+    m_TransformParent: {fileID: 3875912433766751761}
     m_Modifications:
-    - target: {fileID: 3480799786280795482, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 16913060310045154, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
-      propertyPath: m_text
-      value: Avatar added successfully
+      propertyPath: _characterSelectedText
+      value: Replace character model
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 16913060310045154, guid: 8ed70138b742ab140baaaa735bc4f83b,
+        type: 3}
+      propertyPath: _noCharacterSelectedText
+      value: Set character model
+      objectReference: {fileID: 0}
+    - target: {fileID: 1879515266705915738, guid: 8ed70138b742ab140baaaa735bc4f83b,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 5658132884886014261, guid: 8ed70138b742ab140baaaa735bc4f83b,
+        type: 3}
+      propertyPath: m_Name
+      value: CharacterModelSelectionElement
+      objectReference: {fileID: 0}
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_Pivot.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_Pivot.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_AnchorMax.x
-      value: 0
+      value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
-        type: 3}
-      propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
-      propertyPath: m_AnchorMin.y
+      propertyPath: m_AnchorMin.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_SizeDelta.x
-      value: 343.7985
+      value: 202
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_SizeDelta.y
-      value: 22
+      value: 272
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 60
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -11
+      value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+    - target: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6827875814765932863, guid: 857f826e2b56f452aa920cb3e2fba89a,
-        type: 3}
-      propertyPath: m_Name
-      value: MainLabelText_Spatial
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 857f826e2b56f452aa920cb3e2fba89a, type: 3}
---- !u!224 &2015322687953273987 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 8ed70138b742ab140baaaa735bc4f83b, type: 3}
+--- !u!224 &2953338260653742333 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5770951140013856479, guid: 857f826e2b56f452aa920cb3e2fba89a,
+  m_CorrespondingSourceObject: {fileID: 5899030315763646477, guid: 8ed70138b742ab140baaaa735bc4f83b,
     type: 3}
-  m_PrefabInstance: {fileID: 5467744000483316316}
+  m_PrefabInstance: {fileID: 8728483302703126768}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &8727372479419648274 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 16913060310045154, guid: 8ed70138b742ab140baaaa735bc4f83b,
+    type: 3}
+  m_PrefabInstance: {fileID: 8728483302703126768}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f0f27e52e8c23fa45abac303ae587f00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/MirageXR/Prefabs/SpatialScreens/Popups/ChangeUserAvatar.prefab
+++ b/Assets/MirageXR/Prefabs/SpatialScreens/Popups/ChangeUserAvatar.prefab
@@ -812,6 +812,7 @@ MonoBehaviour:
   _closeWindowBtn: {fileID: 1661849700783613301}
   _openEditorBtn: {fileID: 8832294078494451603}
   _characterModelSelectionElement: {fileID: 8727372479419648274}
+  _replaceModelBtn: {fileID: 294528987899187972}
   _avatarLibraryMenu: {fileID: 2782676072868575070, guid: bf7d55a09be4e4e0591dd7985ec12309,
     type: 3}
 --- !u!1 &7793655198397837752
@@ -1840,6 +1841,18 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7f9686d3825704428b6404d181397b79, type: 3}
+--- !u!114 &294528987899187972 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2202299330201409524, guid: 7f9686d3825704428b6404d181397b79,
+    type: 3}
+  m_PrefabInstance: {fileID: 1911288893403366640}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &8116156631587317280 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 7648275913448383184, guid: 7f9686d3825704428b6404d181397b79,

--- a/Assets/MirageXR/Prefabs/SpatialScreens/Popups/ChangeUserAvatar.prefab
+++ b/Assets/MirageXR/Prefabs/SpatialScreens/Popups/ChangeUserAvatar.prefab
@@ -223,41 +223,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 3.7
---- !u!1 &3094301985059019969
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7820014643193127613}
-  m_Layer: 0
-  m_Name: Spacer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &7820014643193127613
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3094301985059019969}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6994616335414442954}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 420, y: 6}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &3225161419562899521
 GameObject:
   m_ObjectHideFlags: 0
@@ -365,7 +330,6 @@ RectTransform:
   - {fileID: 5764171882107036858}
   - {fileID: 3719514645108809969}
   - {fileID: 831870524671889656}
-  - {fileID: 7820014643193127613}
   m_Father: {fileID: 8473332119307211519}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -845,7 +809,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b780291dd4dd6c84b8228b1136908a28, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _confirmationPanel: {fileID: 0}
   _closeWindowBtn: {fileID: 1661849700783613301}
   _openEditorBtn: {fileID: 8832294078494451603}
   _characterModelSelectionElement: {fileID: 8727372479419648274}

--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLibraryManager.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLibraryManager.cs
@@ -58,6 +58,11 @@ namespace MirageXR
 			}
 		}
 
+		public bool ContainsAvatar(string avatarUrl)
+		{
+			return AvatarList.Contains(avatarUrl);
+		}
+
 		public async Task<Texture2D> GetThumbnailAsync(string avatarUrl)
 		{
 			if (!AvatarList.Contains(avatarUrl))


### PR DESCRIPTION
This pull request reuses the menu for selecting a ReadyPlayerMe character for the Virtual Instructors in the avatar selection.

When selecting an avatar, the URL input field is replaced with a gallery consisting of thumbnails of previously loaded models. New avatars can be loaded by entering their URL in a submenu or by adding them through the deep link as before.
![grafik](https://github.com/user-attachments/assets/dc0e0ed1-08e4-4391-ad8e-1013aabbe001)

There is now also a thumbnail of the currently selected avatar so that users always have an indication of their current appearance.
![grafik](https://github.com/user-attachments/assets/b9bd55f3-2235-4166-9eb3-8bf7e0e1d8a7)

The avatars and virtual instructor galleries share one storage, so any model imported as an avatar is automatically available as a virtual instructor and vice versa.