### PR TITLE
Avatar Library Initialization

### DIFF
--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/Loading/AvatarLibraryManager.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/Loading/AvatarLibraryManager.cs
@@ -28,8 +28,12 @@ namespace MirageXR
 			{
 				string json = File.ReadAllText(AvatarLibraryPath);
 				AvatarList = JsonConvert.DeserializeObject<List<string>>(json);
-				_cachedAvatarThumbnails.Clear();
 			}
+			else
+			{
+				AvatarList = new List<string>() { AvatarLoader.DefaultAvatarUrl };
+			}
+			_cachedAvatarThumbnails.Clear();
 		}
 
 		public void Save()

--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/Loading/AvatarLoader.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/Loading/AvatarLoader.cs
@@ -12,7 +12,7 @@ namespace MirageXR
 	public class AvatarLoader : MonoBehaviour
 	{
 		[Tooltip("The URL for the default avatar model.")]
-		[SerializeField] private string defaultAvatarUrl = defaultAvatarUrl;
+		[SerializeField] private string defaultAvatarUrl = "";
 		[Tooltip("An avatar prefab to be used as the default avatar (takes priority over the default avatar URL)")]
 		[SerializeField] private GameObject defaultAvatarPrefab;
 		[Tooltip("ReadyPlayerMe configuration settings for the avatar.")]
@@ -125,6 +125,10 @@ namespace MirageXR
 				else
 				{
 					Debug.LogTrace("Loading default avatar");
+					if (string.IsNullOrEmpty(defaultAvatarUrl))
+					{
+						defaultAvatarUrl = DefaultAvatarUrl;
+					}
 					LoadAvatar(defaultAvatarUrl);
 				}
 			}

--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/Loading/AvatarLoader.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/Loading/AvatarLoader.cs
@@ -12,7 +12,7 @@ namespace MirageXR
 	public class AvatarLoader : MonoBehaviour
 	{
 		[Tooltip("The URL for the default avatar model.")]
-		[SerializeField] private string defaultAvatarUrl = "https://models.readyplayer.me/667bed8204fd145bd9e09f19.glb";
+		[SerializeField] private string defaultAvatarUrl = defaultAvatarUrl;
 		[Tooltip("An avatar prefab to be used as the default avatar (takes priority over the default avatar URL)")]
 		[SerializeField] private GameObject defaultAvatarPrefab;
 		[Tooltip("ReadyPlayerMe configuration settings for the avatar.")]
@@ -23,6 +23,8 @@ namespace MirageXR
 		[field: SerializeField] public bool LoadDefaultAvatarOnStart { get; set; } = true;
 		[Tooltip("Outputs ReadyPlayerMe logs if true")]
 		[SerializeField] private bool detailedRPMLogs = false;
+
+		public const string DefaultAvatarUrl = "https://models.readyplayer.me/667bed8204fd145bd9e09f19.glb";
 
 		// Instance of ReadyPlayerMe's AvatarObjectLoader, responsible for loading avatar assets.
 		private AvatarObjectLoader _avatarObjectLoader;


### PR DESCRIPTION
This pull request fixes #2372.

If the app is freshly installed or its cache was cleared, the avatar library now gets initialized with the default avatar so that there is always one avatar in the gallery.

The pull request also adjusts the way how the default avatar is loaded: If the developers did not specify a default avatar URL but want to load a default avatar, a fallback URL is now used. This fallback URL corresponds to the avatar which is also used to initialize the gallery.