### PR TITLE
Update to i5 Toolkit 1.9.6

### DIFF
--- a/Assets/MirageXR/Managers/PointCloudManager.cs
+++ b/Assets/MirageXR/Managers/PointCloudManager.cs
@@ -18,7 +18,7 @@ public class PointCloudManager : MonoBehaviour
         UnityEngine.Debug.Log("Initializing [PointCloudManager] <--");
         _viewManager = viewManager;
 #if !UNITY_ANDROID && !UNITY_IOS && !UNITY_VISIONOS
-        return true;
+        return;
 #endif
         var mainCamera = _viewManager.Camera;
 

--- a/Assets/MirageXR/Services/IBM-Watson/DialogueService.cs
+++ b/Assets/MirageXR/Services/IBM-Watson/DialogueService.cs
@@ -1,4 +1,3 @@
-using i5.Toolkit.Core.VerboseLogging;
 using IBM.Cloud.SDK;
 using IBM.Watson.Assistant.V2;
 using IBM.Watson.Assistant.V2.Model;
@@ -7,6 +6,8 @@ using UnityEngine;
 using UnityEngine.UI;
 using System.Threading.Tasks;
 using MirageXR;
+using i5.Toolkit.Core.VerboseLogging;
+using i5LogLevel = i5.Toolkit.Core.VerboseLogging.LogLevel;
 
 public enum AIservice
 {
@@ -108,7 +109,7 @@ public class DialogueService : MonoBehaviour
         Debug.Log("[DialogueService] Existing session available");
         if (AI == AIservice.OpenAI)
         {
-            AppLog.Log($"[DialogueService] sending message to chatGPT = '{text}'", LogLevel.INFO);
+            AppLog.Log($"[DialogueService] sending message to chatGPT = '{text}'", i5LogLevel.INFO);
 
             try
             {
@@ -122,7 +123,7 @@ public class DialogueService : MonoBehaviour
                         return;
                     }
                     
-                    AppLog.Log("[DialogueService] starting to parse", LogLevel.INFO);
+                    AppLog.Log("[DialogueService] starting to parse", i5LogLevel.INFO);
                     ParseResponse(response);
                 }
             }
@@ -260,7 +261,7 @@ public class DialogueService : MonoBehaviour
 
     public void OnInputReceived(string text)
     {
-        AppLog.LogWarning($"[Dialogue Service] onInputReceived arrived in DialogueService ='{text}'", LogLevel.INFO);
+        AppLog.LogWarning($"[Dialogue Service] onInputReceived arrived in DialogueService ='{text}'", i5LogLevel.INFO);
         ResponseTextField.text = text;
         SendMessageToAssistantAsync(text).AsAsyncVoid();
     }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -34,7 +34,7 @@
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.github-glitchenzo.nugetforunity": "https://github.com/GlitchEnzo/NuGetForUnity.git?path=/src/NuGetForUnity",
     "com.hecomi.ulipsync": "3.1.4",
-    "com.i5.toolkit.core": "1.9.5",
+    "com.i5.toolkit.core": "1.9.6",
     "com.jetxr.visionui": "https://github.com/jetstyle/Apple-Vision-Pro-UI-Kit.git",
     "com.microsoft.mixedreality.openxr": "file:MixedReality/com.microsoft.mixedreality.openxr-1.10.0.tgz",
     "com.microsoft.mixedreality.toolkit.standardassets": "file:MixedReality/com.microsoft.mixedreality.toolkit.standardassets-2.8.3.tgz",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -58,7 +58,7 @@
       "url": "https://registry.npmjs.com"
     },
     "com.i5.toolkit.core": {
-      "version": "1.9.5",
+      "version": "1.9.6",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
This pull request updates to version 1.9.6 of the i5 Toolkit.

It fixes the receiving methods of OpenID Connect logins getting stripped. It also moved the `LogLevel` enum into a namespace to avoid naming conflicts.