### PR TITLE
Room twin startup fix

### DIFF
--- a/Assets/MirageXR/Scenes/Start.unity
+++ b/Assets/MirageXR/Scenes/Start.unity
@@ -1641,7 +1641,7 @@ MonoBehaviour:
   ForceRoomTwinDisplay: 0
   RoomFile: esa_iss_columbus_module_1m.glb
   RoomTwinShader: {fileID: 2100000, guid: 9a50ae51ad83340f7b9b656c34cfd6aa, type: 2}
-  _roomTwinStyle: 0
+  _roomTwinStyle: 2
 --- !u!1001 &8856608567612908826
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
* RoomTwinManager was missing preselected Room Twin Style setting (to FullTwin), which is serialized; added, which updates the Start scene 

Resolves: #2467