### PR TITLE
shadow jitter fix

### DIFF
--- a/Assets/MirageXR/Rendering/Universal Render Pipeline Asset_Renderer.asset
+++ b/Assets/MirageXR/Rendering/Universal Render Pipeline Asset_Renderer.asset
@@ -99,7 +99,7 @@ MonoBehaviour:
     failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1
-  m_RenderingMode: 0
+  m_RenderingMode: 1
   m_DepthPrimingMode: 0
   m_CopyDepthMode: 1
   m_DepthAttachmentFormat: 0

--- a/Assets/MirageXR/Scenes/Start.unity
+++ b/Assets/MirageXR/Scenes/Start.unity
@@ -815,7 +815,7 @@ Light:
   m_InnerSpotAngle: 21.80208
   m_CookieSize: 10
   m_Shadows:
-    m_Type: 1
+    m_Type: 2
     m_Resolution: -1
     m_CustomResolution: -1
     m_Strength: 1


### PR DESCRIPTION
* URP asset renderer: rendering path now set to deferred (was forward+)
* direction light: shadow type = soft shadow (was hard shadow)

resolves #2488 and #2453 and #2427