### PR TITLE
Initialization fix for the avatar library

### DIFF
--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/Loading/AvatarLibraryManager.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/Loading/AvatarLibraryManager.cs
@@ -33,7 +33,8 @@ namespace MirageXR
 			}
 			else
 			{
-				AvatarList = new List<string>() { AvatarLoader.DefaultAvatarUrl };
+				AvatarList = new List<string>();
+				AddAvatar(AvatarLoader.DefaultAvatarUrl);
 			}
 			_cachedAvatarThumbnails.Clear();
 		}


### PR DESCRIPTION
This pull request fixes a bug where the thumbnail of the default avatar is not loaded if the avatar library file does not exist yet.

The old initialization still wrote the entire avatar URL of the default avatar into the library but this then clashed with the changed behavior where the library only expects that IDs are stored in it.

resolves #2475