### PR TITLE
Spatial avatar fix

### DIFF
--- a/Assets/MirageXR/ContentTypes/VirtualInstructor/Editors/SpatialUI/AddEditVirtualInstructor.cs
+++ b/Assets/MirageXR/ContentTypes/VirtualInstructor/Editors/SpatialUI/AddEditVirtualInstructor.cs
@@ -318,11 +318,11 @@ public class AddEditVirtualInstructor : EditorSpatialView   //TODO: rename to Vi
         avatarModelSettingPanel.gameObject.SetActive(true);
     }
 
-	private void OnAvatarModelSelected(string characterModelUrl)
+	private void OnAvatarModelSelected(string characterModelId)
 	{
         _useReadyPlayerMe = true;
-        _characterModelUrl = characterModelUrl;
-        characterModelSelectionElement.Thumbnail.CharacterModelId = _characterModelUrl;
+        _characterModelUrl = AvatarLoadUtils.IdToModelUrl(characterModelId);
+        characterModelSelectionElement.Thumbnail.CharacterModelId = characterModelId;
 	}
 
 	private void OpenCommunicationSettingPanel()

--- a/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLoadUtils.cs
+++ b/Assets/MirageXR/ReadyPlayerMe/Scripts/AvatarLoadUtils.cs
@@ -14,13 +14,20 @@ namespace MirageXR
     {
         public static string ExtractIdFromUrl(string avatarUrl)
         {
-            Uri uri = new Uri(avatarUrl);
-            Dictionary<string, string> queryParams = UriUtils.GetUriParameters(uri);
-            if (queryParams.TryGetValue("avatar_name", out string name))
+            if (Uri.TryCreate(avatarUrl, UriKind.Absolute, out Uri uri))
             {
-                return name;
+                Dictionary<string, string> queryParams = UriUtils.GetUriParameters(uri);
+                if (queryParams.TryGetValue("avatar_name", out string name))
+                {
+                    return name;
+                }
+                return "";
             }
-            return "";
+            else
+            {
+                Debug.LogWarning(avatarUrl + " is not a URL, returning it as is.");
+                return avatarUrl;
+            }
         }
 
         public static string GetId(string urlOrId)


### PR DESCRIPTION
This pull request corrects a small difference between the ways how the spatial and mobile UI handle avatar IDs vs. URLs.

It also adds more robustness to the avatar loading procedure as the conversion of URLs to IDs will now return the original string if it could not be parsed as a URL - hinting that it might already be an ID.