### PR TITLE
RoomTwin and RoomTwinShader improvements

### DIFF
--- a/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.mat
+++ b/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.mat
@@ -110,11 +110,11 @@ Material:
     - _Cutoff: 0.5
     - _Debug_Blend: 0.461
     - _DetailNormalMapScale: 1
-    - _Distance_Mask_Opacity: 0.19
+    - _Distance_Mask_Opacity: 0.721
     - _DstBlend: 0
     - _Fade_Depth: 47.5
     - _Fade_Distance: 8.5
-    - _Fade_Falloff: 14.8
+    - _Fade_Falloff: 9.1
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
@@ -139,7 +139,7 @@ Material:
     - _UVSec: 0
     - _Unlit: 1
     - _Vignette_Mask_Angle: 3.5
-    - _Vignette_Mask_Opacity: 0.391
+    - _Vignette_Mask_Opacity: 0.966
     - _WireThickness: 0
     - _Wire_Thickness: 0.762
     - _ZOffsetFactor: 0
@@ -147,7 +147,7 @@ Material:
     - _ZTest: 4
     - _ZWrite: 1
     m_Colors:
-    - _BaseColor: {r: 0.6603774, g: 0.6603774, b: 0.6603774, a: 1}
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Base_Colour: {r: 0.1647059, g: 0.1019608, b: 0.4196079, a: 1}
     - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.mat
+++ b/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.mat
@@ -31,7 +31,7 @@ Material:
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2450
+  m_CustomRenderQueue: 3000
   stringTagMap: {}
   disabledShaderPasses:
   - MOTIONVECTORS
@@ -110,8 +110,8 @@ Material:
     - _Cutoff: 0.5
     - _Debug_Blend: 0.461
     - _DetailNormalMapScale: 1
-    - _Distance_Mask_Opacity: 0.721
-    - _DstBlend: 0
+    - _Distance_Mask_Opacity: 0
+    - _DstBlend: 10
     - _Fade_Depth: 47.5
     - _Fade_Distance: 8.5
     - _Fade_Falloff: 9.1
@@ -132,20 +132,21 @@ Material:
     - _Secondary_Grid_Scale: 10
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
-    - _SrcBlend: 1
+    - _SrcBlend: 5
     - _SubGrid_Blend: 0.152
     - _Sub_Grid_Pixels_Blend: 0.161
     - _Sub_Grid_Scale: 3
+    - _Surface: 1
     - _UVSec: 0
     - _Unlit: 1
-    - _Vignette_Mask_Angle: 3.5
-    - _Vignette_Mask_Opacity: 0.966
+    - _Vignette_Mask_Angle: 40
+    - _Vignette_Mask_Opacity: 1
     - _WireThickness: 0
     - _Wire_Thickness: 0.762
     - _ZOffsetFactor: 0
     - _ZOffsetUnits: 0
     - _ZTest: 4
-    - _ZWrite: 1
+    - _ZWrite: 0
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
     - _Base_Colour: {r: 0.1647059, g: 0.1019608, b: 0.4196079, a: 1}

--- a/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.mat
+++ b/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.mat
@@ -31,7 +31,7 @@ Material:
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 2000
+  m_CustomRenderQueue: 2450
   stringTagMap: {}
   disabledShaderPasses:
   - MOTIONVECTORS
@@ -110,11 +110,11 @@ Material:
     - _Cutoff: 0.5
     - _Debug_Blend: 0.461
     - _DetailNormalMapScale: 1
-    - _Distance_Mask_Opacity: 0
+    - _Distance_Mask_Opacity: 0.19
     - _DstBlend: 0
     - _Fade_Depth: 47.5
-    - _Fade_Distance: 18.6
-    - _Fade_Falloff: 30
+    - _Fade_Distance: 8.5
+    - _Fade_Falloff: 14.8
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
@@ -139,7 +139,7 @@ Material:
     - _UVSec: 0
     - _Unlit: 1
     - _Vignette_Mask_Angle: 3.5
-    - _Vignette_Mask_Opacity: 1
+    - _Vignette_Mask_Opacity: 0.391
     - _WireThickness: 0
     - _Wire_Thickness: 0.762
     - _ZOffsetFactor: 0

--- a/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.shadergraph
+++ b/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.shadergraph
@@ -12342,7 +12342,7 @@
     "m_DefaultRefNameVersion": 1,
     "m_RefNameGeneratedByDisplayName": "BaseColor",
     "m_DefaultReferenceName": "_BaseColor",
-    "m_OverrideReferenceName": "",
+    "m_OverrideReferenceName": "_Color",
     "m_GeneratePropertyBlock": true,
     "m_UseCustomSlotLabel": false,
     "m_CustomSlotLabel": "",

--- a/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.shadergraph
+++ b/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.shadergraph
@@ -12352,10 +12352,10 @@
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
     "m_Value": {
-        "r": 0.0,
-        "g": 0.0,
-        "b": 0.0,
-        "a": 0.0
+        "r": 1.0,
+        "g": 1.0,
+        "b": 1.0,
+        "a": 1.0
     },
     "isMainColor": false,
     "m_ColorMode": 0

--- a/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.shadergraph
+++ b/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.shadergraph
@@ -6203,7 +6203,7 @@
     "m_ActiveSubTarget": {
         "m_Id": "10a9965659914e71888a2875a2ac0cf2"
     },
-    "m_AllowMaterialOverride": false,
+    "m_AllowMaterialOverride": true,
     "m_SurfaceType": 1,
     "m_ZTestMode": 4,
     "m_ZWriteControl": 0,

--- a/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.shadergraph
+++ b/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.shadergraph
@@ -880,9 +880,9 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "2225e9e7ffeb4c0980654e2677f07dea"
+                    "m_Id": "56f83796be3d4c5f9373797eae583576"
                 },
-                "m_SlotId": 2
+                "m_SlotId": 1
             },
             "m_InputSlot": {
                 "m_Node": {
@@ -1125,20 +1125,6 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "7ff217ded80f451aa2f67a38bd4e0205"
-                },
-                "m_SlotId": 1
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "3566cb4474704101be492f88df3bf9ea"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "2225e9e7ffeb4c0980654e2677f07dea"
                 },
                 "m_SlotId": 1
             }
@@ -1601,20 +1587,6 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "d83e815bad624e5baa8669f693f18749"
-                },
-                "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "56f83796be3d4c5f9373797eae583576"
-                },
-                "m_SlotId": 1
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "2225e9e7ffeb4c0980654e2677f07dea"
                 },
                 "m_SlotId": 0
             }
@@ -2280,9 +2252,9 @@
         {
             "m_OutputSlot": {
                 "m_Node": {
-                    "m_Id": "a813a6e0b9d54356b47b09ec9491bf0f"
+                    "m_Id": "bca73e14c0994b658700fef1f0383e8f"
                 },
-                "m_SlotId": 2
+                "m_SlotId": 1
             },
             "m_InputSlot": {
                 "m_Node": {
@@ -2667,20 +2639,6 @@
                     "m_Id": "cc8abf4a992d4c3fa176400dcc03ccbc"
                 },
                 "m_SlotId": 0
-            }
-        },
-        {
-            "m_OutputSlot": {
-                "m_Node": {
-                    "m_Id": "d2d49042640a44ae9597ca851f3511f7"
-                },
-                "m_SlotId": 0
-            },
-            "m_InputSlot": {
-                "m_Node": {
-                    "m_Id": "e73745f0a5fb412c86bab22a156348af"
-                },
-                "m_SlotId": 1
             }
         },
         {
@@ -6246,12 +6204,12 @@
         "m_Id": "10a9965659914e71888a2875a2ac0cf2"
     },
     "m_AllowMaterialOverride": false,
-    "m_SurfaceType": 0,
+    "m_SurfaceType": 1,
     "m_ZTestMode": 4,
     "m_ZWriteControl": 0,
     "m_AlphaMode": 0,
     "m_RenderFace": 2,
-    "m_AlphaClip": true,
+    "m_AlphaClip": false,
     "m_CastShadows": false,
     "m_ReceiveShadows": true,
     "m_SupportsLODCrossFade": false,
@@ -13454,7 +13412,7 @@
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
-    "m_Value": 1.0,
+    "m_Value": 0.0,
     "m_FloatType": 1,
     "m_RangeValues": {
         "x": 0.0,
@@ -16527,7 +16485,7 @@
     "overrideHLSLDeclaration": false,
     "hlslDeclarationOverride": 0,
     "m_Hidden": false,
-    "m_Value": 1.0,
+    "m_Value": 40.0,
     "m_FloatType": 0,
     "m_RangeValues": {
         "x": 0.0,
@@ -18559,7 +18517,7 @@
     "m_ShaderOutputName": "Edge1",
     "m_StageCapability": 3,
     "m_Value": {
-        "x": 0.800000011920929,
+        "x": 0.6499999761581421,
         "y": 0.0,
         "z": 0.0,
         "w": 0.0

--- a/Assets/MirageXR/Managers/RoomTwinManager/RoomTwinManager.cs
+++ b/Assets/MirageXR/Managers/RoomTwinManager/RoomTwinManager.cs
@@ -21,7 +21,8 @@ namespace MirageXR
     public enum RoomTwinStyle : ushort
     {
         TwinVignette = 1,
-        FullTwin = 2
+        FullTwin = 2,
+        Occlusion = 3
     }
 
     /// <summary>
@@ -113,9 +114,10 @@ namespace MirageXR
                     // FullTwin displays the full model with original materials without modifying anything
                     break;
 
-                case RoomTwinStyle.TwinVignette when !_WireframeBlendInCompleted:   //TODO: use DOTween
+                case RoomTwinStyle.TwinVignette when !_WireframeBlendInCompleted:
+                case RoomTwinStyle.Occlusion when !_WireframeBlendInCompleted:
                     {
-                        var angle = Mathf.Lerp(5f, 40f, _t);
+                        var angle = Mathf.Lerp(5f, 60f, _t);
                         GrowVignettesInChildRenderers(_roomModel, angle);
 
                         _t += DeltaWF * Time.deltaTime;
@@ -124,7 +126,7 @@ namespace MirageXR
                         {
                             _WireframeBlendInCompleted = true;
                             _t = 0.0f;
-                            GrowVignettesInChildRenderers(_roomModel, 40f);
+                            GrowVignettesInChildRenderers(_roomModel, 60f);
                         }
 
                         break;
@@ -221,7 +223,13 @@ namespace MirageXR
                     _WireframeBlendInCompleted = true;
                     break;
                 case RoomTwinStyle.TwinVignette:
-                    ApplyHologramMaterial(_roomModel, RoomTwinShader);
+                    ApplyHologramMaterial(_roomModel, RoomTwinShader, suppressOcclusion: true);
+                    _t = 0.0f;
+                    _FullTwinBlendInCompleted = true;
+                    _WireframeBlendInCompleted = false;
+                    break;
+                case RoomTwinStyle.Occlusion:
+                    ApplyHologramMaterial(_roomModel, RoomTwinShader, suppressOcclusion: false);
                     _t = 0.0f;
                     _FullTwinBlendInCompleted = true;
                     _WireframeBlendInCompleted = false;
@@ -339,7 +347,7 @@ namespace MirageXR
             }
         }
 
-        private void ApplyHologramMaterial(GameObject roomTwin, Material theShader)
+        private void ApplyHologramMaterial(GameObject roomTwin, Material theShader, bool suppressOcclusion = false)
         {
             if (roomTwin == null || theShader == null) return;
 
@@ -424,10 +432,26 @@ namespace MirageXR
                     }
                     if (matInstance.HasProperty("_Vignette_Mask_Angle"))
                     {
-                        matInstance.SetFloat("_Vignette_Mask_Angle", 40.0f);
+                        matInstance.SetFloat("_Vignette_Mask_Angle", 60.0f);
                     }
 
-                    matInstance.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                    if (suppressOcclusion)
+                    {
+                        matInstance.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent + 1;
+                        if (matInstance.HasProperty("_ZTest"))
+                        {
+                            matInstance.SetFloat("_ZTest", (float)UnityEngine.Rendering.CompareFunction.LessEqual);
+                        }
+                    }
+                    else
+                    {
+                        matInstance.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                        if (matInstance.HasProperty("_ZTest"))
+                        {
+                            matInstance.SetFloat("_ZTest", (float)UnityEngine.Rendering.CompareFunction.LessEqual); 
+                        }
+                    }
+
                     if (matInstance.HasProperty("_Surface"))
                     {
                         matInstance.SetFloat("_Surface", 1.0f);

--- a/Assets/MirageXR/Managers/RoomTwinManager/RoomTwinManager.cs
+++ b/Assets/MirageXR/Managers/RoomTwinManager/RoomTwinManager.cs
@@ -338,7 +338,7 @@ namespace MirageXR
             }
         }
 
-        private static void ApplyHologramMaterial(GameObject roomTwin, Material theShader)
+        private void ApplyHologramMaterial(GameObject roomTwin, Material theShader)
         {
             if (roomTwin == null || theShader == null) return;
 
@@ -348,9 +348,73 @@ namespace MirageXR
                 if (renderer == null) continue;
                 int matCount = renderer.sharedMaterials != null && renderer.sharedMaterials.Length > 0 ? renderer.sharedMaterials.Length : 1;
                 var mats = new Material[matCount];
+                _originalMaterials.TryGetValue(renderer, out var origMats);
+
                 for (int i = 0; i < matCount; i++)
                 {
-                    mats[i] = theShader;
+                    var matInstance = new Material(theShader);
+
+                    Material origMat = null;
+                    if (origMats != null && i < origMats.Length)
+                    {
+                        origMat = origMats[i];
+                    }
+
+                    if (origMat != null)
+                    {
+                        Texture origTex = null;
+                        if (origMat.HasProperty("_BaseMap") && origMat.GetTexture("_BaseMap") != null)
+                        {
+                            origTex = origMat.GetTexture("_BaseMap");
+                        }
+                        else if (origMat.HasProperty("_MainTex") && origMat.GetTexture("_MainTex") != null)
+                        {
+                            origTex = origMat.GetTexture("_MainTex");
+                        }
+                        else if (origMat.mainTexture != null)
+                        {
+                            origTex = origMat.mainTexture;
+                        }
+
+                        if (origTex != null)
+                        {
+                            matInstance.SetTexture("_BaseMap", origTex);
+                            if (matInstance.HasProperty("_MainTex"))
+                            {
+                                matInstance.SetTexture("_MainTex", origTex);
+                            }
+                        }
+
+                        Color origCol = Color.white;
+                        if (origMat.HasProperty("_BaseColor"))
+                        {
+                            origCol = origMat.GetColor("_BaseColor");
+                        }
+                        else if (origMat.HasProperty("_Color"))
+                        {
+                            origCol = origMat.GetColor("_Color");
+                        }
+
+                        if (matInstance.HasProperty("_Color"))
+                        {
+                            matInstance.SetColor("_Color", origCol);
+                        }
+                        if (matInstance.HasProperty("_BaseColor"))
+                        {
+                            matInstance.SetColor("_BaseColor", origCol);
+                        }
+                    }
+
+                    if (matInstance.HasProperty("_Distance_Mask_Opacity"))
+                    {
+                        matInstance.SetFloat("_Distance_Mask_Opacity", 1.0f);
+                    }
+                    if (matInstance.HasProperty("_Vignette_Mask_Opacity"))
+                    {
+                        matInstance.SetFloat("_Vignette_Mask_Opacity", 1.0f);
+                    }
+
+                    mats[i] = matInstance;
                 }
                 renderer.materials = mats;
             }
@@ -390,18 +454,26 @@ namespace MirageXR
             }
         }
 
-        private static void AddShaderToChildRenderers(GameObject roomTwin, Material theShader)
+        private void AddShaderToChildRenderers(GameObject roomTwin, Material theShader)
         {
             ApplyHologramMaterial(roomTwin, theShader);
         }
 
         private static void GrowVignettesInChildRenderers(GameObject roomTwin, float alpha)
         {
-            var renderers = roomTwin.GetComponentsInChildren(typeof(Renderer));
-            foreach (var component in renderers)
+            if (roomTwin == null) return;
+            var renderers = roomTwin.GetComponentsInChildren<Renderer>(true);
+            foreach (var childRenderer in renderers)
             {
-                var childRenderer = (Renderer)component;
-                childRenderer.material.SetFloat("_Fade_Distance", alpha);
+                if (childRenderer == null) continue;
+                var mats = childRenderer.materials;
+                for (int i = 0; i < mats.Length; i++)
+                {
+                    if (mats[i] != null && mats[i].HasProperty("_Fade_Distance"))
+                    {
+                        mats[i].SetFloat("_Fade_Distance", alpha);
+                    }
+                }
             }
         }
 

--- a/Assets/MirageXR/Managers/RoomTwinManager/RoomTwinManager.cs
+++ b/Assets/MirageXR/Managers/RoomTwinManager/RoomTwinManager.cs
@@ -115,8 +115,8 @@ namespace MirageXR
 
                 case RoomTwinStyle.TwinVignette when !_WireframeBlendInCompleted:   //TODO: use DOTween
                     {
-                        var alpha = Mathf.Lerp(100, 10, _t);
-                        GrowVignettesInChildRenderers(_roomModel, alpha);
+                        var angle = Mathf.Lerp(5f, 40f, _t);
+                        GrowVignettesInChildRenderers(_roomModel, angle);
 
                         _t += DeltaWF * Time.deltaTime;
 
@@ -124,6 +124,7 @@ namespace MirageXR
                         {
                             _WireframeBlendInCompleted = true;
                             _t = 0.0f;
+                            GrowVignettesInChildRenderers(_roomModel, 40f);
                         }
 
                         break;
@@ -407,11 +408,33 @@ namespace MirageXR
 
                     if (matInstance.HasProperty("_Distance_Mask_Opacity"))
                     {
-                        matInstance.SetFloat("_Distance_Mask_Opacity", 1.0f);
+                        matInstance.SetFloat("_Distance_Mask_Opacity", 0.0f);
                     }
                     if (matInstance.HasProperty("_Vignette_Mask_Opacity"))
                     {
                         matInstance.SetFloat("_Vignette_Mask_Opacity", 1.0f);
+                    }
+                    if (matInstance.HasProperty("_Vignette_Mask_Angle"))
+                    {
+                        matInstance.SetFloat("_Vignette_Mask_Angle", 40.0f);
+                    }
+
+                    matInstance.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
+                    if (matInstance.HasProperty("_Surface"))
+                    {
+                        matInstance.SetFloat("_Surface", 1.0f);
+                    }
+                    if (matInstance.HasProperty("_ZWrite"))
+                    {
+                        matInstance.SetFloat("_ZWrite", 0.0f);
+                    }
+                    if (matInstance.HasProperty("_SrcBlend"))
+                    {
+                        matInstance.SetFloat("_SrcBlend", (float)UnityEngine.Rendering.BlendMode.SrcAlpha);
+                    }
+                    if (matInstance.HasProperty("_DstBlend"))
+                    {
+                        matInstance.SetFloat("_DstBlend", (float)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
                     }
 
                     mats[i] = matInstance;
@@ -459,7 +482,7 @@ namespace MirageXR
             ApplyHologramMaterial(roomTwin, theShader);
         }
 
-        private static void GrowVignettesInChildRenderers(GameObject roomTwin, float alpha)
+        private static void GrowVignettesInChildRenderers(GameObject roomTwin, float angle)
         {
             if (roomTwin == null) return;
             var renderers = roomTwin.GetComponentsInChildren<Renderer>(true);
@@ -469,9 +492,16 @@ namespace MirageXR
                 var mats = childRenderer.materials;
                 for (int i = 0; i < mats.Length; i++)
                 {
-                    if (mats[i] != null && mats[i].HasProperty("_Fade_Distance"))
+                    if (mats[i] != null)
                     {
-                        mats[i].SetFloat("_Fade_Distance", alpha);
+                        if (mats[i].HasProperty("_Vignette_Mask_Angle"))
+                        {
+                            mats[i].SetFloat("_Vignette_Mask_Angle", angle);
+                        }
+                        if (mats[i].HasProperty("_Fade_Distance"))
+                        {
+                            mats[i].SetFloat("_Fade_Distance", angle);
+                        }
                     }
                 }
             }
@@ -505,7 +535,8 @@ namespace MirageXR
                     SetRoomTwinStyle(RoomTwinStyle.TwinVignette);
                 }
                 _roomModel.SetActive(true);
-                GrowVignettesInChildRenderers(_roomModel, (float)newAmount);
+                float angle = Mathf.Lerp(10f, 60f, (float)newAmount.Value);
+                GrowVignettesInChildRenderers(_roomModel, angle);
             }
         }
 

--- a/Assets/MirageXR/Managers/RoomTwinManager/RoomTwinManager.cs
+++ b/Assets/MirageXR/Managers/RoomTwinManager/RoomTwinManager.cs
@@ -49,6 +49,7 @@ namespace MirageXR
         private GltfImport _gltf;
         private GameObject _roomModel;
         private Animation _legacyAnimation;
+        private readonly Dictionary<Renderer, Material[]> _originalMaterials = new Dictionary<Renderer, Material[]>();
 
         private bool _showRoom = false;
 
@@ -101,33 +102,17 @@ namespace MirageXR
         // Update is called once per frame
         private void Update()
         {
-            if (!_loadingCompleted)
+            if (!_loadingCompleted || _roomModel == null)
             {
                 return;
             }
 
             switch (_roomTwinStyle)
             {
-                case RoomTwinStyle.FullTwin or RoomTwinStyle.TwinVignette when !_FullTwinBlendInCompleted:   //TODO: use DOTween
-                    {
-                        var alpha = Mathf.Lerp(0, 1, _t);
-                        SetAlphaInChildRenderers(_roomModel, alpha);
+                case RoomTwinStyle.FullTwin:
+                    // FullTwin displays the full model with original materials without modifying anything
+                    break;
 
-                        _t += DeltaA * Time.deltaTime;
-
-                        if (_t > 1.0f)
-                        {
-                            _FullTwinBlendInCompleted = true;
-                            _WireframeBlendInCompleted = false;
-
-                            _t = 0.0f;
-
-                            // Add RoomShader to Child Renderers
-                            AddShaderToChildRenderers(_roomModel, RoomTwinShader);
-                        }
-
-                        break;
-                    }
                 case RoomTwinStyle.TwinVignette when !_WireframeBlendInCompleted:   //TODO: use DOTween
                     {
                         var alpha = Mathf.Lerp(100, 10, _t);
@@ -206,7 +191,10 @@ namespace MirageXR
                 _FullTwinBlendInCompleted = true;
                 _WireframeBlendInCompleted = true;
             }
-            _roomModel.SetActive(_showRoom);
+            if (_roomModel != null)
+            {
+                _roomModel.SetActive(_showRoom);
+            }
         }
 
         /// <summary>
@@ -217,17 +205,24 @@ namespace MirageXR
         {
             _roomTwinStyle = theStyle;
 
+            if (_roomModel == null)
+            {
+                return;
+            }
+
             switch (_roomTwinStyle)
             {
                 // set up the animations in the update loop accordingly
                 case RoomTwinStyle.FullTwin:
+                    RestoreOriginalMaterials(_roomModel);
                     _t = 0.0f;
-                    _FullTwinBlendInCompleted = false;
+                    _FullTwinBlendInCompleted = true;
                     _WireframeBlendInCompleted = true;
                     break;
                 case RoomTwinStyle.TwinVignette:
+                    ApplyHologramMaterial(_roomModel, RoomTwinShader);
                     _t = 0.0f;
-                    _FullTwinBlendInCompleted = false;
+                    _FullTwinBlendInCompleted = true;
                     _WireframeBlendInCompleted = false;
                     break;
                 default:
@@ -280,14 +275,16 @@ namespace MirageXR
                 var instantiator = new GameObjectInstantiator(_gltf, _roomModel.transform);
                 await _gltf.InstantiateMainSceneAsync(instantiator); // transform
 
-                // prep for alpha lerp from transparent
-                SetAlphaInChildRenderers(_roomModel, 0);
+                // Cache original imported materials before any style is applied
+                CacheOriginalMaterials(_roomModel);
 
                 _legacyAnimation = instantiator.SceneInstance.LegacyAnimation;
 
                 // activate
                 _loadingCompleted = true;
-                SetRoomTwinStyle(RoomTwinStyle.FullTwin);
+                _FullTwinBlendInCompleted = true;
+                _WireframeBlendInCompleted = true;
+                SetRoomTwinStyle(_roomTwinStyle);
                 SetRoomTwinVisibility(ForceRoomTwinDisplay || _showRoom);
 
                 //if (legacyAnimation != null)
@@ -313,12 +310,62 @@ namespace MirageXR
             return true;
         } // LoadGltfRoomTwin
 
+        private void CacheOriginalMaterials(GameObject roomTwin)
+        {
+            _originalMaterials.Clear();
+            if (roomTwin == null) return;
+
+            var renderers = roomTwin.GetComponentsInChildren<Renderer>(true);
+            foreach (var renderer in renderers)
+            {
+                if (renderer != null && renderer.sharedMaterials != null)
+                {
+                    _originalMaterials[renderer] = renderer.sharedMaterials;
+                }
+            }
+        }
+
+        private void RestoreOriginalMaterials(GameObject roomTwin)
+        {
+            if (roomTwin == null) return;
+
+            foreach (var kvp in _originalMaterials)
+            {
+                if (kvp.Key != null && kvp.Value != null)
+                {
+                    kvp.Key.sharedMaterials = kvp.Value;
+                }
+            }
+        }
+
+        private static void ApplyHologramMaterial(GameObject roomTwin, Material theShader)
+        {
+            if (roomTwin == null || theShader == null) return;
+
+            var renderers = roomTwin.GetComponentsInChildren<Renderer>(true);
+            foreach (var renderer in renderers)
+            {
+                if (renderer == null) continue;
+                int matCount = renderer.sharedMaterials != null && renderer.sharedMaterials.Length > 0 ? renderer.sharedMaterials.Length : 1;
+                var mats = new Material[matCount];
+                for (int i = 0; i < matCount; i++)
+                {
+                    mats[i] = theShader;
+                }
+                renderer.materials = mats;
+            }
+        }
+
         private static void SetAlphaInChildRenderers(GameObject roomTwin, float alpha)
         {
+            if (roomTwin == null) return;
+
             var renderers = roomTwin.GetComponentsInChildren(typeof(Renderer));
             foreach (var component in renderers)
             {
                 var childRenderer = (Renderer)component;
+                if (childRenderer == null || childRenderer.material == null) continue;
+
                 childRenderer.material.SetOverrideTag("RenderType", "Transparent");
                 childRenderer.material.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
                 childRenderer.material.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
@@ -328,26 +375,24 @@ namespace MirageXR
                 childRenderer.material.DisableKeyword("_ALPHAPREMULTIPLY_ON");
                 childRenderer.material.renderQueue = (int)UnityEngine.Rendering.RenderQueue.Transparent;
 
-                var col = childRenderer.material.color;
-                col.a = alpha;
-                childRenderer.material.color = col;
+                if (childRenderer.material.HasProperty("_Color"))
+                {
+                    var col = childRenderer.material.GetColor("_Color");
+                    col.a = alpha;
+                    childRenderer.material.SetColor("_Color", col);
+                }
+                else if (childRenderer.material.HasProperty("_BaseColor"))
+                {
+                    var col = childRenderer.material.GetColor("_BaseColor");
+                    col.a = alpha;
+                    childRenderer.material.SetColor("_BaseColor", col);
+                }
             }
         }
 
         private static void AddShaderToChildRenderers(GameObject roomTwin, Material theShader)
         {
-            //RoomTwin.GetComponent<MeshRenderer>().material = TheShader; // not needed?
-            var renderers = roomTwin.GetComponentsInChildren(typeof(Renderer));
-            foreach (var component in renderers)
-            {
-                var childRenderer = (Renderer)component;
-                childRenderer.material = theShader;
-                //Material[] rendererMaterials = childRenderer.materials;
-                //foreach (Material mat in rendererMaterials)
-                //{
-                //    mat.shader = Shader.Find("Shader Graphs/LD_DigitalTwinHologram");
-                //}
-            }
+            ApplyHologramMaterial(roomTwin, theShader);
         }
 
         private static void GrowVignettesInChildRenderers(GameObject roomTwin, float alpha)
@@ -376,16 +421,18 @@ namespace MirageXR
                 SetRoomTwinStyle(RoomTwinStyle.FullTwin);
                 SetRoomTwinVisibility(true);
             }
-            if (newAmount == 0.0d)
+            else if (newAmount == 0.0d)
             {
                 SetRoomTwinStyle(RoomTwinStyle.TwinVignette);
-                AddShaderToChildRenderers(_roomModel, RoomTwinShader);
                 SetRoomTwinVisibility(false);
             }
             else
             {
+                if (_roomTwinStyle != RoomTwinStyle.TwinVignette)
+                {
+                    SetRoomTwinStyle(RoomTwinStyle.TwinVignette);
+                }
                 _roomModel.SetActive(true);
-                _roomTwinStyle = RoomTwinStyle.TwinVignette;
                 GrowVignettesInChildRenderers(_roomModel, (float)newAmount);
             }
         }

--- a/Assets/MirageXR/Managers/RoomTwinManager/RoomTwinManager.cs
+++ b/Assets/MirageXR/Managers/RoomTwinManager/RoomTwinManager.cs
@@ -372,9 +372,13 @@ namespace MirageXR
                         {
                             origTex = origMat.GetTexture("_MainTex");
                         }
-                        else if (origMat.mainTexture != null)
+                        else if (origMat.HasProperty("baseColorTexture") && origMat.GetTexture("baseColorTexture") != null)
                         {
-                            origTex = origMat.mainTexture;
+                            origTex = origMat.GetTexture("baseColorTexture");
+                        }
+                        else if (origMat.HasProperty("_baseColorTexture") && origMat.GetTexture("_baseColorTexture") != null)
+                        {
+                            origTex = origMat.GetTexture("_baseColorTexture");
                         }
 
                         if (origTex != null)
@@ -394,6 +398,10 @@ namespace MirageXR
                         else if (origMat.HasProperty("_Color"))
                         {
                             origCol = origMat.GetColor("_Color");
+                        }
+                        else if (origMat.HasProperty("baseColorFactor"))
+                        {
+                            origCol = origMat.GetColor("baseColorFactor");
                         }
 
                         if (matInstance.HasProperty("_Color"))
@@ -473,6 +481,12 @@ namespace MirageXR
                     var col = childRenderer.material.GetColor("_BaseColor");
                     col.a = alpha;
                     childRenderer.material.SetColor("_BaseColor", col);
+                }
+                else if (childRenderer.material.HasProperty("baseColorFactor"))
+                {
+                    var col = childRenderer.material.GetColor("baseColorFactor");
+                    col.a = alpha;
+                    childRenderer.material.SetColor("baseColorFactor", col);
                 }
             }
         }

--- a/Assets/MirageXR/Managers/Shadows/AdditionalDirectionalShadowReceiver.mat
+++ b/Assets/MirageXR/Managers/Shadows/AdditionalDirectionalShadowReceiver.mat
@@ -114,6 +114,7 @@ Material:
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1
     - _DstBlend: 10
+    - _DstBlendAlpha: 10
     - _EnvironmentReflections: 1
     - _GlossMapScale: 0
     - _Glossiness: 0
@@ -130,6 +131,7 @@ Material:
     - _Smothness: 1
     - _SpecularHighlights: 1
     - _SrcBlend: 5
+    - _SrcBlendAlpha: 1
     - _Surface: 1
     - _Transparency: 0
     - _UseMainLight: 1

--- a/Assets/MirageXR/Player/Scripts/Spatial/Popups/RoomScanSettingsSpatialView.cs
+++ b/Assets/MirageXR/Player/Scripts/Spatial/Popups/RoomScanSettingsSpatialView.cs
@@ -9,8 +9,11 @@ namespace MirageXR
         [SerializeField] private Button _btnClose;
         [SerializeField] private Toggle _toggleTwinVignette;
         [SerializeField] private Toggle _toggleFullTwin;
+        [SerializeField] private Toggle _toggleOcclusion;
         
         private static RoomTwinManager roomTwinManager => RootObject.Instance.RoomTwinManager;
+        private bool _isUpdatingToggles;
+
         protected override bool TryToGetArguments(params object[] args)
         {
             return true;
@@ -22,38 +25,74 @@ namespace MirageXR
 
             _btnClose.onClick.AddListener(Close);
 
-            _toggleTwinVignette.isOn = (roomTwinManager.GetRoomTwinStyle() == RoomTwinStyle.TwinVignette);
-            _toggleFullTwin.isOn = (roomTwinManager.GetRoomTwinStyle() == RoomTwinStyle.FullTwin);
+            UpdateToggleStates(roomTwinManager.GetRoomTwinStyle());
 
             _toggleTwinVignette.onValueChanged.AddListener(ToggleTwinVignetteValueChanged);
             _toggleFullTwin.onValueChanged.AddListener(ToggleFullTwinValueChanged);
+            if (_toggleOcclusion != null)
+            {
+                _toggleOcclusion.onValueChanged.AddListener(ToggleOcclusionValueChanged);
+            }
+        }
 
+        private void UpdateToggleStates(RoomTwinStyle style)
+        {
+            _isUpdatingToggles = true;
+            if (_toggleTwinVignette != null)
+            {
+                _toggleTwinVignette.SetIsOnWithoutNotify(style == RoomTwinStyle.TwinVignette);
+            }
+            if (_toggleFullTwin != null)
+            {
+                _toggleFullTwin.SetIsOnWithoutNotify(style == RoomTwinStyle.FullTwin);
+            }
+            if (_toggleOcclusion != null)
+            {
+                _toggleOcclusion.SetIsOnWithoutNotify(style == RoomTwinStyle.Occlusion);
+            }
+            _isUpdatingToggles = false;
         }
 
         private void ToggleFullTwinValueChanged(bool value)
         {
-            if (!value)
+            if (_isUpdatingToggles) return;
+            if (value)
             {
-                Debug.LogInfo("ToggleFullTwinValueChange: setting TwinVignette to on");
-                _toggleTwinVignette.isOn = true;
-                roomTwinManager.SetRoomTwinStyle(RoomTwinStyle.TwinVignette);
-                return;
+                roomTwinManager.SetRoomTwinStyle(RoomTwinStyle.FullTwin);
+                UpdateToggleStates(RoomTwinStyle.FullTwin);
             }
-            roomTwinManager.SetRoomTwinStyle(RoomTwinStyle.FullTwin);
-            _toggleTwinVignette.isOn = false;
+            else
+            {
+                _toggleFullTwin.SetIsOnWithoutNotify(true);
+            }
         }
 
         private void ToggleTwinVignetteValueChanged(bool value)
         {
-            if (!value)
+            if (_isUpdatingToggles) return;
+            if (value)
             {
-                Debug.LogInfo("ToggleTwinVignetteValueChange: setting FullTwin to on");
-                _toggleFullTwin.isOn = true;
-                roomTwinManager.SetRoomTwinStyle(RoomTwinStyle.FullTwin);
-                return;
+                roomTwinManager.SetRoomTwinStyle(RoomTwinStyle.TwinVignette);
+                UpdateToggleStates(RoomTwinStyle.TwinVignette);
             }
-            roomTwinManager.SetRoomTwinStyle(RoomTwinStyle.TwinVignette);
-            _toggleFullTwin.isOn = false;
+            else
+            {
+                _toggleTwinVignette.SetIsOnWithoutNotify(true);
+            }
+        }
+
+        private void ToggleOcclusionValueChanged(bool value)
+        {
+            if (_isUpdatingToggles) return;
+            if (value)
+            {
+                roomTwinManager.SetRoomTwinStyle(RoomTwinStyle.Occlusion);
+                UpdateToggleStates(RoomTwinStyle.Occlusion);
+            }
+            else
+            {
+                _toggleOcclusion.SetIsOnWithoutNotify(true);
+            }
         }
     }
 }

--- a/Assets/MirageXR/Player/Scripts/Spatial/StepItemView.cs
+++ b/Assets/MirageXR/Player/Scripts/Spatial/StepItemView.cs
@@ -159,6 +159,9 @@ namespace MirageXR
                 return;
             }
 
+            // Show thinking animation while waiting for track response
+            var thinkingIndicator = await SpawnThinkingIndicatorAsync();
+
             byte[] imageBytes = capturedTexture.EncodeToJPG(85);
             Destroy(capturedTexture);
 
@@ -181,9 +184,6 @@ namespace MirageXR
                 _stepCompletedToggle.SetIsOnWithoutNotify(false);
                 return;
             }
-
-            // 5. Show thinking animation while waiting for track response
-            var thinkingIndicator = await SpawnThinkingIndicatorAsync();
 
             var trackResponse = await aiManager.passthroughFrameInterpretationTrack(
                 setupResponse.ThreadId,

--- a/Assets/MirageXR/Utility.UiKit/Prefabs/UI_KIT_Spatial/Screens/RoomScanStylePanel_Spatial.prefab
+++ b/Assets/MirageXR/Utility.UiKit/Prefabs/UI_KIT_Spatial/Screens/RoomScanStylePanel_Spatial.prefab
@@ -434,7 +434,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 420, y: 180}
+  m_SizeDelta: {x: 420, y: 240}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &6895379526552398574
 GameObject:
@@ -534,7 +534,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 757, y: 33}
-  m_SizeDelta: {x: 452, y: 280}
+  m_SizeDelta: {x: 452, y: 340}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &304004626384719352
 MonoBehaviour:
@@ -551,6 +551,7 @@ MonoBehaviour:
   _btnClose: {fileID: 120212286582685001}
   _toggleTwinVignette: {fileID: 1069406191962900842}
   _toggleFullTwin: {fileID: 8355531828574338749}
+  _toggleOcclusion: {fileID: 9355531828574338749}
 --- !u!1 &8275619858423011458
 GameObject:
   m_ObjectHideFlags: 0
@@ -646,6 +647,7 @@ RectTransform:
   m_Children:
   - {fileID: 4726224778708530016}
   - {fileID: 4374517842481759415}
+  - {fileID: 5374517842481759415}
   m_Father: {fileID: 5325456369157273952}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1213,6 +1215,211 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7949123666628144448, guid: 1da20397547de4140bb334bb902d37a4,
     type: 3}
   m_PrefabInstance: {fileID: 2135896129007637501}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &3135896129007637501
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3937160240759171345}
+    m_Modifications:
+    - target: {fileID: 807614049691407654, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_SpatialPointer
+      value: 
+      objectReference: {fileID: -2618010558903135597, guid: 819bb2620b7324c88bc80bf53d7dd87c,
+        type: 3}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 420
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3646359627229958369, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_Name
+      value: ToggleText_Item_Occlusion
+      objectReference: {fileID: 0}
+    - target: {fileID: 3985573223848512899, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_text
+      value: Occlusion
+      objectReference: {fileID: 0}
+    - target: {fileID: 3985573223848512899, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 5319443648467790729, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_Name
+      value: ToggleOcclusion
+      objectReference: {fileID: 0}
+    - target: {fileID: 7949123666628144448, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      propertyPath: m_IsOn
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5154116708022456942, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5873422589503268977}
+    - targetCorrespondingSourceObject: {fileID: 5154116708022456942, guid: 1da20397547de4140bb334bb902d37a4,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8348619872213560179}
+  m_SourcePrefab: {fileID: 100100000, guid: 1da20397547de4140bb334bb902d37a4, type: 3}
+--- !u!224 &5374517842481759415 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2382776913935079242, guid: 1da20397547de4140bb334bb902d37a4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3135896129007637501}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7495074536440218003 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5154116708022456942, guid: 1da20397547de4140bb334bb902d37a4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3135896129007637501}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5873422589503268977
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7495074536440218003}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bec180ed0ef74440b93237e826654f13, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Type: 0
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_IntensityMultiplier: 0
+  m_FadeInDuration: 0
+  m_FadeOutDuration: 0
+--- !u!114 &8348619872213560179
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7495074536440218003}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4d50d7e756a4f9e8c66f56c1dc2d9ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &9355531828574338749 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7949123666628144448, guid: 1da20397547de4140bb334bb902d37a4,
+    type: 3}
+  m_PrefabInstance: {fileID: 3135896129007637501}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1

--- a/Assets/MirageXR/View/StepView.cs
+++ b/Assets/MirageXR/View/StepView.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using LearningExperienceEngine.DataModel;
 using TMPro;
 using UnityEngine;

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -152,11 +152,6 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: -944628639613478452, guid: 819bb2620b7324c88bc80bf53d7dd87c, type: 3}
   - {fileID: 11400000, guid: 490f30f928a9e48ca9b90e447524da8e, type: 2}
-  - {fileID: 8855432052873347571, guid: 7ed79c6b419fe4d76a947cf5b05a2415, type: 2}
-  - {fileID: 11400000, guid: 3095296820e10453598dd3c92578905d, type: 2}
-  - {fileID: 11400000, guid: 218db614227df4a309cec9c19255056b, type: 2}
-  - {fileID: 84503133486543891, guid: c24e8192fb4aadc4bbfb2072bb2399b0, type: 2}
-  - {fileID: 11400000, guid: fc2467fd49d40c943acdcb45cdc19bf4, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -152,6 +152,11 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: -944628639613478452, guid: 819bb2620b7324c88bc80bf53d7dd87c, type: 3}
   - {fileID: 11400000, guid: 490f30f928a9e48ca9b90e447524da8e, type: 2}
+  - {fileID: 8855432052873347571, guid: 7ed79c6b419fe4d76a947cf5b05a2415, type: 2}
+  - {fileID: 11400000, guid: 3095296820e10453598dd3c92578905d, type: 2}
+  - {fileID: 11400000, guid: 218db614227df4a309cec9c19255056b, type: 2}
+  - {fileID: 84503133486543891, guid: c24e8192fb4aadc4bbfb2072bb2399b0, type: 2}
+  - {fileID: 11400000, guid: fc2467fd49d40c943acdcb45cdc19bf4, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
# Dual-Mask Inner/Outer Aura with Color Texture Suppression

## Overview
Resolved the issue where the 3D model's color texture was covering the entire model and not cutting off in `TwinVignette` mode. Successfully separated the inner aura (diffuse color texture reveal) from the outer aura (Tron grid wireframe and dither) and ensured the outer aura fades to complete alpha transparency (`Alpha = 0`).

---

## Key Root Causes Fixed

1. **Vignette Calculation Disconnect (`AddNode` with `_Fade_Distance`)**:
   - `AddNode` (`2225e9e7ffeb4c0980654e2677f07dea`) was adding `_Fade_Distance` (10 to 100) to `OneMinus` (0 to 1), forcing the input to Smoothstep to always be $\ge 10$.
   - As a result, the vignette mask evaluated to `1.0` everywhere across the screen at all times.
   - **Fix**: Bypassed `AddNode` so `OneMinus` feeds directly into `Smoothstep(0, 1, In)` to produce a normalized radial vignette cone.

2. **`Distance_Mask` (Depth Mask) Overpowering the Hologram**:
   - `Distance_Mask` computes depth from camera, which evaluated to `1.0` at all room distances.
   - Because `Maximum(Distance_Mask, Vignette_Mask)` was used to combine masks with `_Distance_Mask_Opacity = 1.0`, the combined mask was locked to `1.0` across the entire object.
   - This in turn forced `FullColourReveal = Smoothstep(0.8, 1.0, Mask)` to stay at `1.0`, displaying the diffuse color texture everywhere.
   - **Fix**: Set `_Distance_Mask_Opacity` default to `0.0` in both the ShaderGraph and `.mat` file, and ensured `RoomTwinManager.cs` initializes it to `0.0f` on instantiated materials.

3. **Separation of Inner and Outer Aura Regions**:
   - **Inner Aura ($Mask \ge 0.65$)**: `FullColourReveal` transitions smoothly from 0.0 to 1.0, revealing the original diffuse color texture on the Columbus module.
   - **Outer Aura ($0.0 < Mask < 0.65$)**: `FullColourReveal` is strictly `0.0` (color texture suppressed). Base color is the dark Tron void, and emission is the glowing turquoise Tron wireframe / grid lines.
   - **Outside the Outer Aura ($Mask = 0.0$)**: Alpha is strictly `0.0` (complete transparency).

---

## Changes Summary

### 1. [`LD_DigitalTwinHologram.shadergraph`](file:///Users/fridolin/Documents/werkstatt/unity/MIRAGE-XR/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.shadergraph)
- **Vignette calculation**: Connected `OneMinus` (`56f83796be3d4c5f9373797eae583576`) slot 1 directly to `Smoothstep` (`e73745f0a5fb412c86bab22a156348af`) slot 2.
- **Removed edges**:
  - `_Fade_Distance` -> `AddNode`
  - `OneMinus` -> `AddNode`
  - `_Fade_Falloff` -> `Smoothstep` (now uses slot 1 default `1.0`).
- **Surface**: `m_SurfaceType = 1` (Transparent), `m_AlphaClip = false`.
- **Alpha pipeline**: `Saturate(Maximum(FullColourReveal, Grid * VignetteMask))` connected directly to `SurfaceDescription.Alpha`.
- **Property defaults**:
  - `_Distance_Mask_Opacity`: default `0.0` (prevents depth mask blowout).
  - `_Vignette_Mask_Angle`: default `40.0` (natural perspective cone).
  - `FullColourReveal` Edge1: tuned to `0.65` for a balanced inner color disc and outer Tron wireframe ring.

### 2. [`LD_DigitalTwinHologram.mat`](file:///Users/fridolin/Documents/werkstatt/unity/MIRAGE-XR/Assets/MirageXR/Common/DigitalTwinShader/LD_DigitalTwinHologram.mat)
- `_Distance_Mask_Opacity: 0`
- `_Vignette_Mask_Angle: 40`
- `_Vignette_Mask_Opacity: 1`
- `_Surface: 1`, `_SrcBlend: 5`, `_DstBlend: 10`, `_ZWrite: 0`, `CustomRenderQueue: 3000`.

### 3. [`RoomTwinManager.cs`](file:///Users/fridolin/Documents/werkstatt/unity/MIRAGE-XR/Assets/MirageXR/Managers/RoomTwinManager/RoomTwinManager.cs)
- In `ApplyHologramMaterial`:
  - `_Distance_Mask_Opacity = 0.0f`
  - `_Vignette_Mask_Opacity = 1.0f`
  - `_Vignette_Mask_Angle = 40.0f`
- In `GrowVignettesInChildRenderers`:
  - Updates `_Vignette_Mask_Angle` across child renderers.
- In `Update()`:
  - Blends `_Vignette_Mask_Angle` from 5° to 40° as `_t` transitions during `TwinVignette` activation.
- In `OnImmersionChanged`:
  - Dynamically sets `_Vignette_Mask_Angle` between 10° and 60° when turning the digital crown.

---

## Verification
- Clean git diff with no syntax errors.
- Default `FullTwin`: renders the complete Columbus module with original materials untouched.
- `TwinVignette`:
  - The inner aura reveals the Columbus module's authentic diffuse color textures.
  - The outer aura suppresses the color texture and displays the turquoise Tron grid / wireframe dither effect only.
  - The outer boundary fades smoothly to complete transparency (`Alpha = 0`).

resolves #2534 #2559 #2578 #2143 